### PR TITLE
feat: 탐색 페이지 제작

### DIFF
--- a/src/components/place-item-card/PlaceItemCard.test.tsx
+++ b/src/components/place-item-card/PlaceItemCard.test.tsx
@@ -7,7 +7,7 @@ describe('장소 아이템 카드 컴포넌트', () => {
     const mockPlaceInfo = {
       placeId: 1,
       placeName: '그리디 카페',
-      mainPhotoUrl: '/asset/place-item-card/tempImg.svg',
+      mainImageUrl: '/asset/place-item-card/tempImg.svg',
       categories: [
         { categoryId: 1, categoryName: '식당' },
         { categoryId: 2, categoryName: '카페' },

--- a/src/components/place-item-card/PlaceItemCard.tsx
+++ b/src/components/place-item-card/PlaceItemCard.tsx
@@ -21,7 +21,7 @@ const PlaceItemCard = ({ placeInfo }: PlaceItemCardProps) => {
       </div>
       <div className="flex gap-2 p-2">
         {placeInfo.tags.map((tag) => (
-          <TagButton key={tag.tagId}># {tag.tagName}</TagButton>
+          <TagButton key={tag.tagId}>{tag.tagName}</TagButton>
         ))}
       </div>
     </div>

--- a/src/components/place-item-card/PlaceItemCard.tsx
+++ b/src/components/place-item-card/PlaceItemCard.tsx
@@ -3,7 +3,7 @@ import TagButton from '../share/TagButton';
 
 interface PlaceItemCardProps {
   placeInfo: PlaceProps;
-  className: string;
+  className?: string;
 }
 
 const PlaceItemCard = ({ placeInfo, className }: PlaceItemCardProps) => {
@@ -13,7 +13,7 @@ const PlaceItemCard = ({ placeInfo, className }: PlaceItemCardProps) => {
     >
       <div className="mb-3 flex w-full gap-3">
         <img
-          src={placeInfo.mainImgUrl}
+          src={placeInfo.mainImageUrl}
           alt="장소 대표 이미지"
           className="aspect-square w-[30%]"
         />

--- a/src/components/place-item-card/PlaceItemCard.tsx
+++ b/src/components/place-item-card/PlaceItemCard.tsx
@@ -1,12 +1,19 @@
+import type { PlaceProps } from '../../types/type';
 import TagButton from '../share/TagButton';
-import type { PlaceItemCardProps } from './model/type';
 
-const PlaceItemCard = ({ placeInfo }: PlaceItemCardProps) => {
+interface PlaceItemCardProps {
+  placeInfo: PlaceProps;
+  grid: boolean;
+}
+
+const PlaceItemCard = ({ placeInfo, grid }: PlaceItemCardProps) => {
   return (
-    <div className="h-[235px] w-[430px] rounded-[20px] p-3 shadow-[0_0_15px_0_rgba(0,0,0,0.1)]">
+    <div
+      className={`box-border aspect-[16/9] w-[430px] rounded-[20px] p-3 shadow-[0_0_15px_0_rgba(0,0,0,0.1)] ${grid && 'w-full'}`}
+    >
       <div className="mb-3 flex w-full gap-3">
         <img
-          src={placeInfo.mainPhotoUrl}
+          src={placeInfo.mainImgUrl}
           alt="장소 대표 이미지"
           className="aspect-square w-[30%]"
         />
@@ -14,7 +21,7 @@ const PlaceItemCard = ({ placeInfo }: PlaceItemCardProps) => {
           <h3 className="text-lg font-extrabold">{placeInfo.placeName}</h3>
           <div className="flex gap-1 text-xs font-semibold text-[#70553D]">
             {placeInfo.categories.map((category) => (
-              <span>{category.categoryName}</span>
+              <span key={category.categoryId}>{category.categoryName}</span>
             ))}
           </div>
         </div>

--- a/src/components/place-item-card/PlaceItemCard.tsx
+++ b/src/components/place-item-card/PlaceItemCard.tsx
@@ -3,13 +3,13 @@ import TagButton from '../share/TagButton';
 
 interface PlaceItemCardProps {
   placeInfo: PlaceProps;
-  grid: boolean;
+  className: string;
 }
 
-const PlaceItemCard = ({ placeInfo, grid }: PlaceItemCardProps) => {
+const PlaceItemCard = ({ placeInfo, className }: PlaceItemCardProps) => {
   return (
     <div
-      className={`box-border aspect-[16/9] w-[430px] rounded-[20px] p-3 shadow-[0_0_15px_0_rgba(0,0,0,0.1)] ${grid && 'w-full'}`}
+      className={`box-border aspect-[16/9] w-[430px] rounded-[20px] p-3 shadow-[0_0_15px_0_rgba(0,0,0,0.1)] ${className}`}
     >
       <div className="mb-3 flex w-full gap-3">
         <img

--- a/src/components/share/TagButton.tsx
+++ b/src/components/share/TagButton.tsx
@@ -19,12 +19,16 @@ const TagButton = ({
     sizeStyle = 'px-6 py-1 text-xs font-bold';
   }
 
+  if (size === 'middle') {
+    sizeStyle = 'px-4 py-1 text-xs font-bold';
+  }
+
   return (
     <li
       onClick={onClick}
       className={`w-fit rounded-full border border-[#828282] bg-blue-200 text-[#70553D] select-none ${sizeStyle} ${className}`}
     >
-      {children}
+      # {children}
     </li>
   );
 };

--- a/src/context/categoryContext.tsx
+++ b/src/context/categoryContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { CategoryProps } from '../features/discover/model/type';
+import type { CategoryProps } from '../types/type';
 
 interface CategoryContextType {
   selectedCategory: CategoryProps | null;

--- a/src/context/tagContext.tsx
+++ b/src/context/tagContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { TagProps } from '../features/discover/model/type';
+import type { TagProps } from '../types/type';
 
 interface TagContextType {
   selectedTags: TagProps[];

--- a/src/features/discover/apis/filterApi.ts
+++ b/src/features/discover/apis/filterApi.ts
@@ -1,5 +1,5 @@
 import api from '../../../api/api';
-import type { Category, Tag } from '../model/type';
+import type { Category, Tag } from '../../../types/type';
 
 // 카테고리 api
 export const fetchCategories = async (): Promise<Category> => {
@@ -7,7 +7,7 @@ export const fetchCategories = async (): Promise<Category> => {
   return response.data;
 };
 
-// 카테고리병 태그 api
+// 카테고리별 태그 api
 export const fetchCategoryTags = async (categoryId: number): Promise<Tag> => {
   const response = await api.get(`/tags/${categoryId}`);
   return response.data;

--- a/src/features/discover/apis/placeApi.ts
+++ b/src/features/discover/apis/placeApi.ts
@@ -1,0 +1,19 @@
+import api from '../../../api/api';
+import type { CategoryProps, Place, TagProps } from '../../../types/type';
+
+// 필터된 장소 api
+export const fetchFilteredPlaces = async (
+  selectedCategory: CategoryProps,
+  selectedTags: TagProps[],
+): Promise<Place> => {
+  const params = new URLSearchParams();
+  params.append('category', String(selectedCategory.categoryId));
+
+  if (selectedTags.length > 0) {
+    const tagIds = selectedTags.map((tag) => tag.tagId).join(',');
+    params.append('tags', tagIds);
+  }
+
+  const response = await api.get(`/places?${params.toString()}`);
+  return response.data;
+};

--- a/src/features/discover/components/CategoryFilter.tsx
+++ b/src/features/discover/components/CategoryFilter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useCategory } from '../../../hooks/useCategory';
-import type { CategoryProps } from '../model/type';
+import type { CategoryProps } from '../../../types/type';
 import { fetchCategories } from '../apis/filterApi';
 
 const CategoryFilter = () => {

--- a/src/features/discover/components/DiscoverItem.tsx
+++ b/src/features/discover/components/DiscoverItem.tsx
@@ -47,7 +47,11 @@ const DiscoverItem = () => {
       </h1>
       <div className="grid w-full grid-cols-3 gap-3">
         {filteredPlaces.map((place) => (
-          <PlaceItemCard key={place.placeId} placeInfo={place} grid={true} />
+          <PlaceItemCard
+            key={place.placeId}
+            placeInfo={place}
+            className="w-full"
+          />
         ))}
       </div>
     </div>

--- a/src/features/discover/components/DiscoverItem.tsx
+++ b/src/features/discover/components/DiscoverItem.tsx
@@ -1,17 +1,34 @@
+import { useEffect, useState } from 'react';
+import PlaceItemCard from '../../../components/place-item-card/PlaceItemCard';
 import TagButton from '../../../components/share/TagButton';
+import { useCategory } from '../../../hooks/useCategory';
 import { useTag } from '../../../hooks/useTag';
-import type { TagProps } from '../model/type';
+import type { PlaceProps, TagProps } from '../../../types/type';
+import { fetchFilteredPlaces } from '../apis/placeApi';
 
 const DiscoverItem = () => {
+  const { selectedCategory } = useCategory();
   const { selectedTags, toggleTag } = useTag();
+  const [filteredPlaces, setFilteredPlaces] = useState<PlaceProps[]>([]);
+  console.log(filteredPlaces);
+  useEffect(() => {
+    const fetchFilterPlace = async () => {
+      if (selectedCategory && selectedTags) {
+        const res = await fetchFilteredPlaces(selectedCategory, selectedTags);
+        setFilteredPlaces(res.data);
+      }
+    };
+
+    fetchFilterPlace();
+  }, [selectedCategory, selectedTags]);
 
   const handleTag = (tag: TagProps) => {
     toggleTag(tag);
   };
 
   return (
-    <div className="w-full py-20">
-      <ul className="flex gap-2">
+    <div className="flex w-full flex-col gap-4 py-20">
+      <ul className="flex gap-2 px-2">
         {selectedTags.map((tag) => (
           <TagButton
             key={tag.tagId}
@@ -25,6 +42,14 @@ const DiscoverItem = () => {
           </TagButton>
         ))}
       </ul>
+      <h1 className="w-full bg-[#B2E5E880] px-3 py-2 indent-5 text-2xl font-extrabold">
+        여기가 딱!
+      </h1>
+      <div className="grid w-full grid-cols-3 gap-3">
+        {filteredPlaces.map((place) => (
+          <PlaceItemCard key={place.placeId} placeInfo={place} grid={true} />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/features/discover/components/DiscoverItem.tsx
+++ b/src/features/discover/components/DiscoverItem.tsx
@@ -1,0 +1,32 @@
+import TagButton from '../../../components/share/TagButton';
+import { useTag } from '../../../hooks/useTag';
+import type { TagProps } from '../model/type';
+
+const DiscoverItem = () => {
+  const { selectedTags, toggleTag } = useTag();
+
+  const handleTag = (tag: TagProps) => {
+    toggleTag(tag);
+  };
+
+  return (
+    <div className="w-full py-20">
+      <ul className="flex gap-2">
+        {selectedTags.map((tag) => (
+          <TagButton
+            key={tag.tagId}
+            size="middle"
+            className="flex items-center justify-center gap-3 px-1"
+          >
+            {tag.tagName}
+            <button className="cursor-pointer" onClick={() => handleTag(tag)}>
+              X
+            </button>
+          </TagButton>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DiscoverItem;

--- a/src/features/discover/components/TagFilter.tsx
+++ b/src/features/discover/components/TagFilter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTag } from '../../../hooks/useTag';
-import type { TagProps } from '../model/type';
+import type { TagProps } from '../../../types/type';
 import { fetchCategoryTags } from '../apis/filterApi';
 import { useCategory } from '../../../hooks/useCategory';
 import TagButton from '../../../components/share/TagButton';

--- a/src/mock/handler/PlaceEndpoints.ts
+++ b/src/mock/handler/PlaceEndpoints.ts
@@ -11,7 +11,7 @@ export const getPlaces = http.get('/sejonglife/api/places', ({ request }) => {
         message: '필수 파라미터(category)가 누락되었습니다.',
         data: null,
       },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -20,6 +20,16 @@ export const getPlaces = http.get('/sejonglife/api/places', ({ request }) => {
       placeId: 1,
       placeName: '시홍쓰',
       mainPhotoUrl: 'https://example.com/shihong.jpg',
+      categories: [
+        {
+          categoryId: 1,
+          categoryName: '식당',
+        },
+        {
+          categoryId: 2,
+          categoryName: '술집',
+        },
+      ],
       tags: [
         {
           tagId: 1,
@@ -35,6 +45,12 @@ export const getPlaces = http.get('/sejonglife/api/places', ({ request }) => {
       placeId: 2,
       placeName: '제주몰빵',
       mainPhotoUrl: 'https://example.com/caffeine.jpg',
+      categories: [
+        {
+          categoryId: 3,
+          categoryName: '카페',
+        },
+      ],
       tags: [
         {
           tagId: 3,
@@ -49,7 +65,7 @@ export const getPlaces = http.get('/sejonglife/api/places', ({ request }) => {
       message: '장소 목록 조회 성공',
       data: mockPlaces,
     },
-    { status: 200 }
+    { status: 200 },
   );
 });
 
@@ -70,7 +86,7 @@ export const getPlaceDetails = http.get(
           message: '해당하는 장소 ID를 찾을 수 없습니다.',
           data: null,
         },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
@@ -98,8 +114,8 @@ export const getPlaceDetails = http.get(
             },
           },
         },
-        { status: 200 }
+        { status: 200 },
       );
     }
-  }
+  },
 );

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -1,3 +1,4 @@
+import DiscoverItem from '../features/discover/components/DiscoverItem';
 import Filter from '../features/discover/components/Filter';
 
 const DiscoverPage = () => {
@@ -5,6 +6,7 @@ const DiscoverPage = () => {
     <div className="flex flex-col px-[20%] py-10">
       <div className="w-full">
         <Filter />
+        <DiscoverItem />
       </div>
     </div>
   );

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -3,7 +3,7 @@ import Filter from '../features/discover/components/Filter';
 
 const DiscoverPage = () => {
   return (
-    <div className="flex flex-col px-[20%] py-10">
+    <div className="flex flex-col px-[15%] py-10">
       <div className="w-full">
         <Filter />
         <DiscoverItem />

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -17,3 +17,16 @@ export interface Tag {
   message: string;
   data: TagProps[];
 }
+
+export interface PlaceProps {
+  placeId: number;
+  placeName: string;
+  mainImgUrl: string;
+  categories: CategoryProps[];
+  tags: TagProps[];
+}
+
+export interface Place {
+  message: string;
+  data: PlaceProps[];
+}

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -21,7 +21,7 @@ export interface Tag {
 export interface PlaceProps {
   placeId: number;
   placeName: string;
-  mainImgUrl: string;
+  mainImageUrl: string;
   categories: CategoryProps[];
   tags: TagProps[];
 }


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 탐색 페이지 제작

### 📋 주요 변경사항 (Key Changes)

- 탐색 페이지 제작
- 태그 제거 기능 추가
- 필터 장소 검색 api 추가

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#14 ] feat: 탐색 페이지 제작

---

### 📸 스크린샷 (Screenshot)

<img width="1898" height="807" alt="image" src="https://github.com/user-attachments/assets/746cdfd2-682c-4baf-a689-02e6cd5d68ba" />

---

### ✅ 참고 사항 (Remarks)

- 장소 api 추가 했습니다. 이 과정에서 장소 모킹 데이터에 카테고리가 추가되었어요.
- 태그 컴포넌트가 반영이 되어 있지 않아서 해결과정에서 이전 pr의 커밋이 따라오게 되었어요 양해부탁드려요!
- 페이지네이션은 아직 계획에 없어서 미구현입니다!
- 