### PR TITLE
fix: 상세페이지 안 뜨는 오류 해결

### DIFF
--- a/src/features/placeDetail/ReviewStats.tsx
+++ b/src/features/placeDetail/ReviewStats.tsx
@@ -20,7 +20,7 @@ const ReviewStats = () => {
         <div className="flex gap-1.5">
           <div className="text-xl text-[#77db30]">★</div>
           <div className="text-xl font-bold text-[#212529]">
-            {stats.averageRate.toFixed(1)}점
+            {stats.averageRate?.toFixed(1) || '0.0'}점
           </div>
         </div>
         <div className="font-semibold text-[#868E96]">


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 상세페이지 오류 해결

### 📋 주요 변경사항 (Key Changes)

- 상세페이지에서 리뷰 평점을 가져올 때 toFixed() 메소드를 이용했는데 이때 평점이 null일 경우에는 toFixed의 사용이 불가하여 오류가 발생했습니다. 이 부분에 대해서 무조건 값이 있을때만 toFixed를 쓰고 아니면 0점 처리하는 것으로 수정했습니다.
- 
---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#57 ]
- **관련 이슈**: [#57 ] 
  - ...

---

### 📸 스크린샷 (Screenshot)

<img width="1459" height="828" alt="image" src="https://github.com/user-attachments/assets/b0b538ab-9394-43b5-b773-283e316ef49b" />

---

### ✅ 참고 사항 (Remarks)
