### PR TITLE
refactor: 뒤로가기 헤더 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ExplorePage from './pages/ExplorePage';
 import AllReviewPage from './pages/AllReviewsPage';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import BackLayout from './layout/BackLayout';
 
 function App() {
   return (
@@ -21,8 +22,10 @@ function App() {
             <Route path="preparingService" element={<PrepareServicePage />} />
             <Route path="explore" element={<ExplorePage />} />
           </Route>
-          <Route path="detail/:id/reviews" element={<AllReviewPage />} />
-          <Route path="write-review/:id" element={<CreateReviewPage />} />
+          <Route path="/" element={<BackLayout />}>
+            <Route path="detail/:id/reviews" element={<AllReviewPage />} />
+            <Route path="write-review/:id" element={<CreateReviewPage />} />
+          </Route>
         </Routes>
       </BrowserRouter>
       <ToastContainer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,14 +18,11 @@ function App() {
           <Route path="/" element={<Layout />}>
             <Route index element={<MainPage />} />
             <Route path="detail/:id" element={<PlaceDetailPage />} />
-            <Route
-              path="write-review/:placeId"
-              element={<CreateReviewPage />}
-            />
             <Route path="preparingService" element={<PrepareServicePage />} />
             <Route path="explore" element={<ExplorePage />} />
           </Route>
-          <Route path="/detail/:id/reviews" element={<AllReviewPage />} />
+          <Route path="detail/:id/reviews" element={<AllReviewPage />} />
+          <Route path="write-review/:id" element={<CreateReviewPage />} />
         </Routes>
       </BrowserRouter>
       <ToastContainer

--- a/src/features/allReviews/AllReviewContainer.tsx
+++ b/src/features/allReviews/AllReviewContainer.tsx
@@ -1,10 +1,8 @@
-import HeaderWithBack from './HeaderWithBack';
 import AllReviewSection from './AllReviewSection';
 
 const AllReviewContainer = () => {
   return (
     <>
-      <HeaderWithBack />
       <AllReviewSection />
     </>
   );

--- a/src/features/allReviews/HeaderWithBack.tsx
+++ b/src/features/allReviews/HeaderWithBack.tsx
@@ -1,7 +1,11 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { usePlaceDetail } from '../../hooks/usePlaceDetail';
 
 const HeaderWithBack = () => {
   const navigate = useNavigate();
+  const { id } = useParams();
+  const { place } = usePlaceDetail(id!);
+
   return (
     <>
       <header className="flex h-14 w-full border-b border-b-[#EEEFF1] px-15 py-2">
@@ -9,8 +13,10 @@ const HeaderWithBack = () => {
           onClick={() => navigate(-1)}
           className="flex items-center gap-5"
         >
-          <img src="/asset/all-review/backArrow.svg" alt="뒤로가기"></img>
-          리뷰
+          <div className="flex items-center gap-2">
+            <img src="/asset/all-review/backArrow.svg" alt="뒤로가기"></img>
+            <span className="font-semibold text-[#354052]">{place?.name}</span>
+          </div>
         </button>
       </header>
     </>

--- a/src/features/createReview/components/CreateReview.tsx
+++ b/src/features/createReview/components/CreateReview.tsx
@@ -7,10 +7,9 @@ import TagButton from '../../../components/share/TagButton';
 import { postReview } from '../api/postReviewApi';
 import StarRating from './StarRating';
 import { toast } from 'react-toastify';
-import HeaderWithBack from '../../allReviews/HeaderWithBack';
 
 const CreateReview = () => {
-  const { placeId } = useParams();
+  const { id } = useParams();
   const navigate = useNavigate();
   const [placeInfo, setPlaceInfo] = useState<DetailPlaceProps>();
   const [tags, setTags] = useState<TagProps[]>([]);
@@ -24,7 +23,7 @@ const CreateReview = () => {
 
   useEffect(() => {
     const fetchPlaceInfo = async () => {
-      const res = await fetchPlaceDetail(Number(placeId));
+      const res = await fetchPlaceDetail(Number(id));
       setPlaceInfo(res.data);
     };
 
@@ -108,10 +107,10 @@ const CreateReview = () => {
         submitData.append('images', file);
       });
 
-      await postReview(Number(placeId), submitData);
+      await postReview(Number(id), submitData);
 
       toast.success('리뷰가 성공적으로 등록되었습니다!');
-      navigate(`/detail/${placeId}`);
+      navigate(`/detail/${id}`);
     } catch (error) {
       console.error(error);
       toast.error('리뷰 등록에 실패했습니다.');
@@ -123,102 +122,103 @@ const CreateReview = () => {
   }
 
   return (
-    <div className="flex h-fit flex-col rounded-2xl border-2 border-gray-300 bg-white py-6 text-[#2C3037]">
-      <HeaderWithBack />
-      <form onSubmit={handleSubmit} className="py-6">
-        <div className="space-y-2 px-10 py-5">
-          <h1 className="text-lg font-bold">
-            방문하신 장소의 별점을 남겨주세요
-          </h1>
-          <StarRating
-            value={formData.rating}
-            onChange={(newRating) =>
-              setFormData((prev) => ({ ...prev, rating: newRating }))
-            }
-          />
-        </div>
-        <div className="space-y-2 p-10">
-          <h4 className="text-lg font-bold">어울리는 태그를 골라주세요!</h4>
-          <div className="custom-scroll max-h-28 space-y-2 space-x-3 overflow-auto rounded-md border border-gray-100 p-3">
-            {tags.map((tag) => {
-              const isSelected = formData.tagIds.includes(tag.tagId);
-              return (
-                <TagButton
-                  key={tag.tagId}
-                  onClick={() => handleSelectedTags(tag.tagId)}
-                  className={isSelected ? 'opacity-100' : 'opacity-60'}
-                >
-                  {tag.tagName}
-                </TagButton>
-              );
-            })}
+    <div className="bg-[#F9FAFB] px-[10%] pt-8">
+      <div className="flex h-fit flex-col rounded-2xl border border-[#EEEFF1] bg-white py-6 text-[#2C3037]">
+        <form onSubmit={handleSubmit} className="py-6">
+          <div className="space-y-2 px-10 py-5">
+            <h1 className="text-lg font-bold">
+              방문하신 장소의 별점을 남겨주세요
+            </h1>
+            <StarRating
+              value={formData.rating}
+              onChange={(newRating) =>
+                setFormData((prev) => ({ ...prev, rating: newRating }))
+              }
+            />
           </div>
-        </div>
-        <div className="flex flex-col gap-2 px-10 py-5">
-          <label htmlFor="review" className="text-lg font-bold">
-            리뷰를 작성해주세요.
-          </label>
-          <textarea
-            name="review"
-            id="review"
-            placeholder="방문한 장소의 리뷰를 남겨주세요!"
-            className="custom-scroll h-40 rounded-md bg-[#F3F3F5] p-3 text-sm"
-            onChange={handleContentChange}
-          />
-        </div>
-        <div className="flex items-center gap-2 px-10 py-5">
-          <input
-            id="imageUpload"
-            name="image"
-            type="file"
-            accept="image/*"
-            multiple
-            onChange={handleImageChange}
-            className="hidden"
-          />
-          <label
-            htmlFor="imageUpload"
-            className="flex h-40 w-40 cursor-pointer items-center justify-center rounded-2xl border-3 border-dashed text-sm text-gray-500 transition-colors duration-150 hover:bg-gray-100"
-          >
-            <div className="flex flex-col items-center gap-1">
-              <img
-                src="/asset/create-review/camera.svg"
-                alt="카메라 아이콘"
-                className="mx-auto mb-1 h-8"
-              />
-              <p>사진을 추가해보세요.</p>
-              <span>사진 {previews.length}</span>
+          <div className="space-y-2 p-10">
+            <h4 className="text-lg font-bold">어울리는 태그를 골라주세요!</h4>
+            <div className="custom-scroll max-h-28 space-y-2 space-x-3 overflow-auto rounded-md border border-gray-100 p-3">
+              {tags.map((tag) => {
+                const isSelected = formData.tagIds.includes(tag.tagId);
+                return (
+                  <TagButton
+                    key={tag.tagId}
+                    onClick={() => handleSelectedTags(tag.tagId)}
+                    className={isSelected ? 'opacity-100' : 'opacity-60'}
+                  >
+                    {tag.tagName}
+                  </TagButton>
+                );
+              })}
             </div>
-          </label>
-
-          <div className="flex gap-2">
-            {previews.map((preview, index) => (
-              <div key={index} className="relative">
-                <img
-                  src={preview}
-                  alt={`preview-${index}`}
-                  className="h-24 w-24 rounded object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => handleRemoveImage(index)}
-                  className="absolute top-1 right-1 cursor-pointer rounded-full bg-black/50 px-1 text-xs text-white"
-                >
-                  ✕
-                </button>
-              </div>
-            ))}
           </div>
-        </div>
-        <div className="flex justify-end px-10 py-5">
-          <button
-            type="submit"
-            className="text-md rounded-2xl bg-[#8BE34A] px-5 py-3 font-bold text-white"
-          >
-            등록하기
-          </button>
-        </div>
-      </form>
+          <div className="flex flex-col gap-2 px-10 py-5">
+            <label htmlFor="review" className="text-lg font-bold">
+              리뷰를 작성해주세요.
+            </label>
+            <textarea
+              name="review"
+              id="review"
+              placeholder="방문한 장소의 리뷰를 남겨주세요!"
+              className="custom-scroll h-40 rounded-md bg-[#F3F3F5] p-3 text-sm"
+              onChange={handleContentChange}
+            />
+          </div>
+          <div className="flex items-center gap-2 px-10 py-5">
+            <input
+              id="imageUpload"
+              name="image"
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleImageChange}
+              className="hidden"
+            />
+            <label
+              htmlFor="imageUpload"
+              className="flex h-40 w-40 cursor-pointer items-center justify-center rounded-2xl border-3 border-dashed text-sm text-gray-500 transition-colors duration-150 hover:bg-gray-100"
+            >
+              <div className="flex flex-col items-center gap-1">
+                <img
+                  src="/asset/create-review/camera.svg"
+                  alt="카메라 아이콘"
+                  className="mx-auto mb-1 h-8"
+                />
+                <p>사진을 추가해보세요.</p>
+                <span>사진 {previews.length}</span>
+              </div>
+            </label>
+
+            <div className="flex gap-2">
+              {previews.map((preview, index) => (
+                <div key={index} className="relative">
+                  <img
+                    src={preview}
+                    alt={`preview-${index}`}
+                    className="h-24 w-24 rounded object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveImage(index)}
+                    className="absolute top-1 right-1 cursor-pointer rounded-full bg-black/50 px-1 text-xs text-white"
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end px-10 py-5">
+            <button
+              type="submit"
+              className="text-md rounded-2xl bg-[#8BE34A] px-5 py-3 font-bold text-white"
+            >
+              등록하기
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/features/placeDetail/PlaceDetailContainer.tsx
+++ b/src/features/placeDetail/PlaceDetailContainer.tsx
@@ -16,7 +16,7 @@ const PlaceDetailContainer = () => {
   if (!place) return <div>로딩중...</div>;
 
   return (
-    <div className="mx-auto mt-12 flex w-[75%] flex-col items-center gap-10 overflow-y-auto">
+    <div className="mx-auto mt-8 flex w-[75%] flex-col items-center gap-10 overflow-y-auto">
       <PhotoStrip images={place.images.map((image) => image.url)} />
       <PlaceInfo place={place} />
       <div className="flex w-full border border-gray-100" />

--- a/src/layout/BackLayout.tsx
+++ b/src/layout/BackLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import HeaderWithBack from '../features/allReviews/HeaderWithBack';
+
+const BackLayout = () => {
+  return (
+    <div className="min-h-screen">
+      <HeaderWithBack />
+      <Outlet />
+    </div>
+  );
+};
+
+export default BackLayout;

--- a/src/pages/CreateReviewPage.tsx
+++ b/src/pages/CreateReviewPage.tsx
@@ -1,10 +1,8 @@
 import CreateReview from '../features/createReview/components/CreateReview';
-import HeaderWithBack from '../features/allReviews/HeaderWithBack';
 
 const CreateReviewPage = () => {
   return (
     <div>
-      <HeaderWithBack />
       <CreateReview />
     </div>
   );

--- a/src/pages/CreateReviewPage.tsx
+++ b/src/pages/CreateReviewPage.tsx
@@ -1,8 +1,10 @@
 import CreateReview from '../features/createReview/components/CreateReview';
+import HeaderWithBack from '../features/allReviews/HeaderWithBack';
 
 const CreateReviewPage = () => {
   return (
-    <div className="bg-[#F9FAFB] px-[10%] pt-10">
+    <div>
+      <HeaderWithBack />
       <CreateReview />
     </div>
   );


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 뒤로가기 헤더 적용 
- [x] 헤더에 장소명 추가

### 📋 주요 변경사항 (Key Changes)

- 상세페이지에서 클릭이벤트를 통해 이동하는 페이지인 리뷰작성페이지와 전체리뷰 페이지에 대해서 사용자가 예상하고, 기대하는 다음 로직은 기존의 상세장소카드로의 이동이라고 판단하여 이 두가지 페이지의 헤더는 뒤로가기가 있도록 수정했습니다.
- 헤더에 뒤로라기 이모지 옆에는 장소의 명을 작성하여 보일 수 있도록 했습니다.
- 또한 이때 두가지 페이지에 대해서는 동일한 헤더를 사용하기때문에 outlet을 이용해서 구현하고자 했으나 place.name을 가져와서 띄우는 로직으로 수정하면서 첫 렌더시에는 플레이스가 null 로 넘어오면서 오류가 발생하게 되었습니다. 결국 이에대해서는 라우터를 각자 두고 각 페이지 내에서 헤더 컴포넌트를 재사용하도록 수정했습니다.

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#70 ]
- **관련 이슈**: [#70 ]

---

### 📸 스크린샷 (Screenshot)
<img width="1512" height="797" alt="image" src="https://github.com/user-attachments/assets/82d56407-6f21-4cc5-8fef-bee08a560f66" />
---

### ✅ 참고 사항 (Remarks)
그리고 지금 깃허브 올라간 파일 체인지드를 보니까 뭘 되게 createReview 컴포넌트 내에서 제가 뭘 많이 건든것마냥 나오는데 전체를 감싸는 div 추가하고 스타일 준거랑, placeId로 쓰던 변수명을 id로 변경한 것 밖에 없습니다 !
