### PR TITLE
fix: 플레이스 api 요청 파라미터 변경

### DIFF
--- a/src/features/explore/apis/placeApi.ts
+++ b/src/features/explore/apis/placeApi.ts
@@ -1,16 +1,16 @@
-import type { CategoryProps, Place, TagProps } from '../../../types/type';
+import type { Place } from '../../../types/type';
 import { api } from '../../../api/api';
 
 // 필터된 장소 api
 export const fetchFilteredPlaces = async (
-  selectedCategory: CategoryProps,
-  selectedTags: TagProps[],
+  selectedCategory: string,
+  selectedTags: string[],
 ): Promise<Place> => {
   const params = new URLSearchParams();
-  params.append('category', String(selectedCategory.categoryId));
+  params.append('category', String(selectedCategory));
 
   if (selectedTags.length > 0) {
-    const tagNames = selectedTags.map((tag) => tag.tagName).join(',');
+    const tagNames = selectedTags.map((tag) => tag).join(',');
     params.append('tags', tagNames);
   }
 

--- a/src/features/explore/components/ExploreItem.tsx
+++ b/src/features/explore/components/ExploreItem.tsx
@@ -26,16 +26,16 @@ const ExploreItem = () => {
 
   const handleTag = (tagName: string) => {
     const newParams = new URLSearchParams(location.search);
-    const currentTags = newParams.getAll('tags');
+    const currentTags = new Set(newParams.getAll('tags'));
 
-    if (currentTags.includes(tagName)) {
-      newParams.delete('tags');
-      currentTags
-        .filter((tag) => tag !== tagName)
-        .forEach((tag) => newParams.append('tags', tag));
+    if (currentTags.has(tagName)) {
+      currentTags.delete(tagName);
     } else {
-      newParams.append('tags', tagName);
+      currentTags.add(tagName);
     }
+
+    newParams.delete('tags');
+    currentTags.forEach((tag) => newParams.append('tags', tag));
 
     navigate({ search: newParams.toString() }, { replace: true });
   };

--- a/src/features/explore/components/ExploreItem.tsx
+++ b/src/features/explore/components/ExploreItem.tsx
@@ -1,42 +1,56 @@
 import { useEffect, useState } from 'react';
 import PlaceItemCard from '../../../components/place-item-card/PlaceItemCard';
 import TagButton from '../../../components/share/TagButton';
-import { useCategory } from '../../../hooks/useCategory';
-import { useTag } from '../../../hooks/useTag';
-import type { PlaceProps, TagProps } from '../../../types/type';
+import type { PlaceProps } from '../../../types/type';
 import { fetchFilteredPlaces } from '../apis/placeApi';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const ExploreItem = () => {
-  const { selectedCategory } = useCategory();
-  const { selectedTags, toggleTag } = useTag();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const categoryFromQuery = params.get('category') || '';
+  const tagsFromQuery = params.getAll('tags') || '';
   const [filteredPlaces, setFilteredPlaces] = useState<PlaceProps[]>([]);
 
   useEffect(() => {
     const fetchFilterPlace = async () => {
-      if (selectedCategory && selectedTags) {
-        const res = await fetchFilteredPlaces(selectedCategory, selectedTags);
+      if (categoryFromQuery && tagsFromQuery) {
+        const res = await fetchFilteredPlaces(categoryFromQuery, tagsFromQuery);
         setFilteredPlaces(res.data || []);
       }
     };
 
     fetchFilterPlace();
-  }, [selectedCategory, selectedTags]);
+  }, [categoryFromQuery, tagsFromQuery]);
 
-  const handleTag = (tag: TagProps) => {
-    toggleTag(tag);
+  const handleTag = (tagName: string) => {
+    const newParams = new URLSearchParams(location.search);
+    const currentTags = newParams.getAll('tags');
+
+    if (currentTags.includes(tagName)) {
+      newParams.delete('tags');
+      currentTags
+        .filter((tag) => tag !== tagName)
+        .forEach((tag) => newParams.append('tags', tag));
+    } else {
+      newParams.append('tags', tagName);
+    }
+
+    navigate({ search: newParams.toString() }, { replace: true });
   };
 
   return (
     <div className="flex w-full flex-col gap-4 py-20">
       <ul className="flex gap-2 px-2">
-        {selectedTags.map((tag) => (
+        {tagsFromQuery.map((tag) => (
           <TagButton
-            key={tag.tagId}
+            key={tag}
             size="middle"
             className="flex cursor-pointer items-center justify-center gap-3 px-1"
             onClick={() => handleTag(tag)}
           >
-            {tag.tagName}
+            {tag}
             <button>X</button>
           </TagButton>
         ))}

--- a/src/features/explore/components/TagFilter.tsx
+++ b/src/features/explore/components/TagFilter.tsx
@@ -9,7 +9,6 @@ const TagFilter = () => {
   const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const categoryName = params.get('category');
-  const [selectedTags, setSelectedTags] = useState<TagProps[]>([]);
   const [tags, setTags] = useState<TagProps[]>([]);
   const [categories, setCategories] = useState<CategoryProps[]>([]);
 
@@ -39,22 +38,10 @@ const TagFilter = () => {
     fetchTag();
   }, [categoryName, categories]);
 
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const tagsFromQuery = params.getAll('tags');
-
-    const newSelectedTags = tags.filter((tag) =>
-      tagsFromQuery.includes(tag.tagName),
-    );
-
-    setSelectedTags(newSelectedTags);
-  }, [location.search, tags]);
-
   const updateQueryParams = (newSelectedTags: TagProps[]) => {
     const searchParams = new URLSearchParams(location.search);
 
     searchParams.delete('tags');
-
     newSelectedTags.forEach((tag) => {
       searchParams.append('tags', tag.tagName);
     });
@@ -63,20 +50,23 @@ const TagFilter = () => {
   };
 
   const toggleTag = (tag: TagProps) => {
-    setSelectedTags((prevTags) => {
-      const isSelected = prevTags.some((t) => t.tagId === tag.tagId);
+    const searchParams = new URLSearchParams(location.search);
+    const tagsFromQuery = new Set(searchParams.getAll('tags'));
 
-      const newSelectedTags = isSelected
-        ? prevTags.filter((t) => t.tagId !== tag.tagId)
-        : [...prevTags, tag];
+    if (tagsFromQuery.has(tag.tagName)) {
+      tagsFromQuery.delete(tag.tagName);
+    } else {
+      tagsFromQuery.add(tag.tagName);
+    }
 
-      updateQueryParams(newSelectedTags);
-      return newSelectedTags;
-    });
+    const newSelectedTags = tags.filter((t) => tagsFromQuery.has(t.tagName));
+    updateQueryParams(newSelectedTags);
   };
 
   const isSelected = (tag: TagProps) => {
-    return selectedTags.some((selectedTag) => selectedTag.tagId === tag.tagId);
+    const searchParams = new URLSearchParams(location.search);
+    const tagsFromQuery = searchParams.getAll('tags');
+    return tagsFromQuery.includes(tag.tagName);
   };
 
   const handleTagClick = (tag: TagProps) => {

--- a/src/features/explore/components/TagFilter.tsx
+++ b/src/features/explore/components/TagFilter.tsx
@@ -39,6 +39,17 @@ const TagFilter = () => {
     fetchTag();
   }, [categoryName, categories]);
 
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const tagsFromQuery = params.getAll('tags');
+
+    const newSelectedTags = tags.filter((tag) =>
+      tagsFromQuery.includes(tag.tagName),
+    );
+
+    setSelectedTags(newSelectedTags);
+  }, [location.search, tags]);
+
   const updateQueryParams = (newSelectedTags: TagProps[]) => {
     const searchParams = new URLSearchParams(location.search);
 

--- a/src/features/explore/components/TagFilter.tsx
+++ b/src/features/explore/components/TagFilter.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useTag } from '../../../hooks/useTag';
 import type { CategoryProps, TagProps } from '../../../types/type';
 import { fetchCategories, fetchCategoryTags } from '../apis/filterApi';
 import TagButton from '../../../components/share/TagButton';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const TagFilter = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const categoryName = params.get('category');
-  const { selectedTags, toggleTag } = useTag();
+  const [selectedTags, setSelectedTags] = useState<TagProps[]>([]);
   const [tags, setTags] = useState<TagProps[]>([]);
   const [categories, setCategories] = useState<CategoryProps[]>([]);
 
@@ -38,6 +38,31 @@ const TagFilter = () => {
 
     fetchTag();
   }, [categoryName, categories]);
+
+  const updateQueryParams = (newSelectedTags: TagProps[]) => {
+    const searchParams = new URLSearchParams(location.search);
+
+    searchParams.delete('tags');
+
+    newSelectedTags.forEach((tag) => {
+      searchParams.append('tags', tag.tagName);
+    });
+
+    navigate({ search: searchParams.toString() }, { replace: true });
+  };
+
+  const toggleTag = (tag: TagProps) => {
+    setSelectedTags((prevTags) => {
+      const isSelected = prevTags.some((t) => t.tagId === tag.tagId);
+
+      const newSelectedTags = isSelected
+        ? prevTags.filter((t) => t.tagId !== tag.tagId)
+        : [...prevTags, tag];
+
+      updateQueryParams(newSelectedTags);
+      return newSelectedTags;
+    });
+  };
 
   const isSelected = (tag: TagProps) => {
     return selectedTags.some((selectedTag) => selectedTag.tagId === tag.tagId);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -43,19 +43,19 @@ const MainPage = () => {
 
         <div className="flex justify-center gap-5 pt-10">
           <PageRouterButton
-            to={`/explore?category=${categories[0]?.categoryName}`}
+            to={`/explore`}
             icon="/asset/pageRouterButton/allItemIcon.svg"
           >
             <div>전체</div>
           </PageRouterButton>
           <PageRouterButton
-            to={`/explore?category=${categories[1]?.categoryName}`}
+            to={`/explore?category=${categories[0]?.categoryName}`}
             icon="/asset/pageRouterButton/restaurantIcon.svg"
           >
             <div>식당</div>
           </PageRouterButton>
           <PageRouterButton
-            to={`/explore?category=${categories[2]?.categoryName}`}
+            to={`/explore?category=${categories[1]?.categoryName}`}
             icon="/asset/pageRouterButton/cafeIcon.svg"
           >
             <div>카페</div>


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 플레이스 api 요청 파라미터 변경

### 📋 주요 변경사항 (Key Changes)

- 이제 태그도 쿼리스트링으로 관리하게 됩니다.
- api 요청시 카테고리와 태그 넘버가 아닌 string값으로 요청합니다.
- 메인 메뉴 라우팅 경로가 알맞게 수정되었습니다.

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#74 ] fix: 플레이스 api 요청 파라미터 변경

---

### 📸 스크린샷 (Screenshot)

<img width="1888" height="963" alt="image" src="https://github.com/user-attachments/assets/6dd6ef5b-7e8b-4fae-8339-11be94c593c3" />

---

### ✅ 참고 사항 (Remarks)

- "전체" 카테고리에 대한 논의가 필요합니다.
- 카테고리&태그 선택 영역 디자인에 대해서 지우님이 언급해주셨는데, 요약하자면 메인 페이지의 디자인을 참고해서 변경하자는 내용이었습니다. 여기에 대해서 좀 더 구체화가 가능하면 업데이트 하겠습니다.