### PR TITLE
refactor: 상세페이지 디자인 및 반응형 처리

### DIFF
--- a/src/features/allReviews/AllReviewSection.tsx
+++ b/src/features/allReviews/AllReviewSection.tsx
@@ -1,21 +1,23 @@
 import { useParams } from 'react-router-dom';
 import PhotoStrip from '../placeDetail/PhotoStrip';
-import ReviewStats from '../placeDetail/ReviewStatsSection';
 import ReviewCard from '../placeDetail/place-review-card/ReviewCard';
 import { usePlaceDetail } from '../../hooks/usePlaceDetail';
 import { usePlaceReview } from '../../hooks/usePlaceReview';
+import { useReviewStats } from '../../hooks/useReviewStats';
+import ReviewStatsSection from '../placeDetail/ReviewStatsSection';
 
 const AllReviewSection = () => {
   const { id } = useParams<{ id: string }>();
   const { place } = usePlaceDetail(id!);
   const { reviews } = usePlaceReview(id!);
+  const { stats } = useReviewStats(id!);
 
-  if (!place || reviews.length === 0) return <div>로딩중...</div>;
+  if (!place || !stats) return <div>로딩중...</div>;
 
   return (
     <div className="mx-auto mt-12 flex w-[75%] flex-col items-center gap-10 overflow-y-auto">
       <PhotoStrip images={place.images.map((image) => image.url)} />
-      <ReviewStats />
+      <ReviewStatsSection stats={stats} />
       <div className="flex w-[90%] flex-col">
         {reviews.map((review) => (
           <>

--- a/src/features/allReviews/AllReviewSection.tsx
+++ b/src/features/allReviews/AllReviewSection.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import PhotoStrip from '../placeDetail/PhotoStrip';
-import ReviewStats from '../placeDetail/ReviewStats';
+import ReviewStats from '../placeDetail/ReviewStatsSection';
 import ReviewCard from '../placeDetail/place-review-card/ReviewCard';
 import { usePlaceDetail } from '../../hooks/usePlaceDetail';
 import { usePlaceReview } from '../../hooks/usePlaceReview';

--- a/src/features/placeDetail/MoreReviewButton.tsx
+++ b/src/features/placeDetail/MoreReviewButton.tsx
@@ -1,6 +1,10 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
-const MoreReviewButton = () => {
+export interface ReviewStatsProps {
+  reviewCount: number;
+}
+
+const MoreReviewButton = ({ reviewCount }: ReviewStatsProps) => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
@@ -10,7 +14,7 @@ const MoreReviewButton = () => {
         onClick={() => navigate(`/detail/${id}/reviews`)}
         className="mb-10 cursor-pointer rounded-xl border border-[#8BE34A] bg-[#77db30] px-6 py-3 font-semibold text-white hover:bg-[#8BE34A]"
       >
-        전체 리뷰 보러가기
+        더 많은 리뷰 보러가기 (+{reviewCount - 2})
       </a>
     </div>
   );

--- a/src/features/placeDetail/PhotoGrid.tsx
+++ b/src/features/placeDetail/PhotoGrid.tsx
@@ -5,7 +5,7 @@ interface PhotoGridProps {
 
 const PhotoGrid = ({ images, onImageClick }: PhotoGridProps) => {
   return (
-    <div className="grid max-h-[40rem] max-w-[50rem] grid-cols-3 gap-0.5 overflow-y-auto bg-white p-0.5">
+    <div className="grid max-h-[40rem] grid-cols-3 gap-0.5 overflow-y-auto bg-white p-0.5">
       {images.map((src, i) => (
         <img
           className="aspect-square w-full cursor-pointer object-cover"

--- a/src/features/placeDetail/PhotoStrip.tsx
+++ b/src/features/placeDetail/PhotoStrip.tsx
@@ -51,7 +51,7 @@ const PhotoStrip = ({ images }: PhotoStripProps) => {
                 background: '#f0f0f0',
               }}
             >
-              <div className="flex gap-2">
+              <div className="flex items-center gap-2">
                 <img
                   src="/asset/place-detail-page/camera.svg"
                   alt="camera"

--- a/src/features/placeDetail/PhotoStrip.tsx
+++ b/src/features/placeDetail/PhotoStrip.tsx
@@ -30,7 +30,7 @@ const PhotoStrip = ({ images }: PhotoStripProps) => {
         {[0, 1, 2].map((i) =>
           images[i] ? (
             <img
-              className="h-full w-1/4 flex-1 object-cover"
+              className="h-full flex-1 object-cover transition-transform duration-300 ease-in-out hover:scale-105"
               key={i}
               src={images[i]}
               alt={`place-${i}`}

--- a/src/features/placeDetail/PlaceDetailContainer.tsx
+++ b/src/features/placeDetail/PlaceDetailContainer.tsx
@@ -1,19 +1,21 @@
 import PhotoStrip from './PhotoStrip';
 import PlaceInfo from './PlaceInfo';
 import { useParams } from 'react-router-dom';
-import ReviewStats from './ReviewStats';
+import ReviewStatsSection from './ReviewStatsSection';
 import ReviewCard from './place-review-card/ReviewCard';
 import ReviewWriteButton from './ReviewWriteButton';
 import MoreReviewButton from './MoreReviewButton';
 import { usePlaceDetail } from '../../hooks/usePlaceDetail';
 import { usePlaceReview } from '../../hooks/usePlaceReview';
+import { useReviewStats } from '../../hooks/useReviewStats';
 
 const PlaceDetailContainer = () => {
   const { id } = useParams<{ id: string }>();
   const { place } = usePlaceDetail(id!);
   const { reviews } = usePlaceReview(id!);
+  const { stats } = useReviewStats(id!);
 
-  if (!place) return <div>로딩중...</div>;
+  if (!place || !stats) return <div>로딩중...</div>;
 
   return (
     <div className="mx-auto mt-12 flex w-[75%] flex-col items-center gap-10 overflow-y-auto">
@@ -22,7 +24,7 @@ const PlaceDetailContainer = () => {
       <div className="flex w-full border border-gray-100" />
       <ReviewWriteButton placeName={place.name} placeId={id!} />
       <div className="flex w-full border border-gray-100" />
-      <ReviewStats />
+      <ReviewStatsSection stats={stats} />
       <div className="flex w-[90%] flex-col">
         {reviews.slice(0, 2).map((review) => (
           <>
@@ -30,7 +32,9 @@ const PlaceDetailContainer = () => {
             <ReviewCard key={review.reviewId} review={review} placeId={id!} />
           </>
         ))}
-        {reviews[2] && <MoreReviewButton />}
+        {reviews.length > 2 && (
+          <MoreReviewButton reviewCount={stats.reviewCount} />
+        )}
       </div>
     </div>
   );

--- a/src/features/placeDetail/PlaceDetailContainer.tsx
+++ b/src/features/placeDetail/PlaceDetailContainer.tsx
@@ -18,14 +18,14 @@ const PlaceDetailContainer = () => {
   if (!place || !stats) return <div>로딩중...</div>;
 
   return (
-    <div className="mx-auto mt-12 flex w-[75%] flex-col items-center gap-10 overflow-y-auto">
+    <div className="mx-auto mt-12 flex w-full max-w-screen-lg flex-col items-center gap-10 overflow-y-auto">
       <PhotoStrip images={place.images.map((image) => image.url)} />
       <PlaceInfo place={place} />
       <div className="flex w-full border border-gray-100" />
       <ReviewWriteButton placeName={place.name} placeId={id!} />
       <div className="flex w-full border border-gray-100" />
       <ReviewStatsSection stats={stats} />
-      <div className="flex w-[90%] flex-col">
+      <div className="flex w-full flex-col sm:w-[90%]">
         {reviews.slice(0, 2).map((review) => (
           <>
             <div className="flex w-full border border-gray-100" />

--- a/src/features/placeDetail/PlaceInfo.tsx
+++ b/src/features/placeDetail/PlaceInfo.tsx
@@ -8,21 +8,21 @@ interface PlaceInfoProps {
 const PlaceInfo = ({ place }: PlaceInfoProps) => {
   return (
     <div className="flex w-[90%] flex-col items-start gap-5">
-      <div className="flex gap-4">
+      <div className="flex items-center gap-4">
         <h1 className="text-2xl font-bold text-[#212529]">{place.name}</h1>
-        <div className="rounded-full bg-[#f0f0f0] px-3.5 pt-2 text-xs">
+        <div className="rounded-full bg-[#f0f0f0] px-3.5 py-1.5 text-xs">
           {place.categories[0].categoryName}
         </div>
       </div>
 
       <div className="text-lg font-semibold text-[#343A40]">
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           <img
             src="/asset/place-detail-page/tag.svg"
             alt="tag"
             className="text-[#77db30]"
           />
-          태그
+          <span>태그</span>
         </div>
         <div className="mt-4 flex flex-wrap gap-2">
           {place.tags.map((tag) => (
@@ -34,9 +34,9 @@ const PlaceInfo = ({ place }: PlaceInfoProps) => {
       </div>
 
       <div className="w-full items-center text-lg font-semibold text-[#343A40]">
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           <img src="/asset/place-detail-page/map.svg" alt="map" />
-          지도 바로가기
+          <span>지도 바로가기</span>
         </div>
         <div className="mt-4 flex w-full justify-between gap-3">
           <a

--- a/src/features/placeDetail/PlaceInfo.tsx
+++ b/src/features/placeDetail/PlaceInfo.tsx
@@ -11,7 +11,11 @@ const PlaceInfo = ({ place }: PlaceInfoProps) => {
       <div className="flex items-center gap-4">
         <h1 className="text-2xl font-bold text-[#212529]">{place.name}</h1>
         <div className="rounded-full bg-[#f0f0f0] px-3.5 py-1.5 text-xs">
-          {place.categories[0].categoryName}
+          {place.categories.map((category) => (
+            <span key={category.categoryId} className="rounded-full">
+              {category.categoryName}
+            </span>
+          ))}
         </div>
       </div>
 

--- a/src/features/placeDetail/PlaceInfo.tsx
+++ b/src/features/placeDetail/PlaceInfo.tsx
@@ -42,25 +42,25 @@ const PlaceInfo = ({ place }: PlaceInfoProps) => {
           <img src="/asset/place-detail-page/map.svg" alt="map" />
           <span>지도 바로가기</span>
         </div>
-        <div className="mt-4 flex w-full justify-between gap-3">
+        <div className="mt-4 grid w-full gap-3 sm:flex sm:justify-between">
           <a
             href={place.mapLinks.naverMap}
             target="_blank"
-            className="flex-1 rounded-2xl bg-[#03C75A] py-3 text-center text-lg text-white transition-colors hover:bg-[#02B350]"
+            className="flex-1 rounded-2xl bg-[#03C75A] py-2 text-center text-white transition-colors hover:bg-[#02B350] sm:py-3 sm:text-lg"
           >
             네이버맵
           </a>
           <a
             href={place.mapLinks.kakaoMap}
             target="_blank"
-            className="flex-1 rounded-2xl bg-[#FEE500] py-3 text-center text-lg transition-colors hover:bg-[#F5D400]"
+            className="flex-1 rounded-2xl bg-[#FEE500] py-2 text-center transition-colors hover:bg-[#F5D400] sm:py-3 sm:text-lg"
           >
             카카오맵
           </a>
           <a
             href={place.mapLinks.googleMap}
             target="_blank"
-            className="flex-1 rounded-2xl bg-[#868E96] py-3 text-center text-lg text-white transition-colors hover:bg-[#6C757D]"
+            className="flex-1 rounded-2xl bg-[#868E96] py-2 text-center text-white transition-colors hover:bg-[#6C757D] sm:py-3 sm:text-lg"
           >
             구글맵
           </a>

--- a/src/features/placeDetail/ReviewStatsSection.tsx
+++ b/src/features/placeDetail/ReviewStatsSection.tsx
@@ -15,7 +15,7 @@ const ReviewStatsSection = ({ stats }: ReviewStatsProps) => {
 
   return (
     <div className="flex w-[90%] flex-col items-start">
-      <div className="flex gap-4">
+      <div className="flex items-center gap-4">
         <div className="flex gap-1.5">
           <div className="text-xl text-[#77db30]">★</div>
           <div className="text-xl font-bold text-[#212529]">

--- a/src/features/placeDetail/ReviewStatsSection.tsx
+++ b/src/features/placeDetail/ReviewStatsSection.tsx
@@ -1,10 +1,9 @@
-import { useParams } from 'react-router-dom';
-import { useReviewStats } from '../../hooks/useReviewStats';
+import type { ReviewStats } from '../../types/type';
 
-const ReviewStats = () => {
-  const { id } = useParams<{ id: string }>();
-  const { stats } = useReviewStats(id!);
-
+export interface ReviewStatsProps {
+  stats: ReviewStats;
+}
+const ReviewStatsSection = ({ stats }: ReviewStatsProps) => {
   if (!stats) {
     return <div> 리뷰 통계 로딩 중...</div>;
   }
@@ -55,4 +54,4 @@ const ReviewStats = () => {
   );
 };
 
-export default ReviewStats;
+export default ReviewStatsSection;

--- a/src/features/placeDetail/ReviewWriteButton.tsx
+++ b/src/features/placeDetail/ReviewWriteButton.tsx
@@ -28,9 +28,9 @@ const ReviewWriteButton = ({ placeName, placeId }: ReviewWiteButtonProps) => {
     <>
       <div className="flex w-[90%] flex-col items-start gap-3 text-lg">
         <div className="flex text-xl font-bold text-[#212529]">
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <img src="/asset/place-detail-page/filePencil.svg" alt="review" />
-            리뷰쓰기
+            <span>리뷰쓰기</span>
           </div>
         </div>
         <div>
@@ -43,9 +43,9 @@ const ReviewWriteButton = ({ placeName, placeId }: ReviewWiteButtonProps) => {
           onClick={handleClickedReviewWriteButton}
           className="flex w-full cursor-pointer items-center justify-center rounded-2xl border border-[#8BE34A] bg-[#77db30] px-6 py-3 font-semibold text-white hover:bg-[#8BE34A]"
         >
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <img src="/asset/place-detail-page/pencil.svg" alt="map" />
-            리뷰쓰기
+            <span>리뷰쓰기</span>
           </div>
         </a>
       </div>

--- a/src/features/placeDetail/apis/reviewApi.ts
+++ b/src/features/placeDetail/apis/reviewApi.ts
@@ -1,4 +1,4 @@
-import type { Review, ReviewStatsProps } from '../../../types/type';
+import type { Review, ReviewStats } from '../../../types/type';
 import { api } from '../../../api/api';
 
 export const getPlaceReview = async (
@@ -22,9 +22,7 @@ export const getPlaceReview = async (
   }
 };
 
-export const getReviewStats = async (
-  placeId: string,
-): Promise<ReviewStatsProps> => {
+export const getReviewStats = async (placeId: string): Promise<ReviewStats> => {
   try {
     const response = await api.get(`/api/places/${placeId}/reviews/summary`);
     return response.data.data;

--- a/src/features/placeDetail/place-review-card/ReviewCard.tsx
+++ b/src/features/placeDetail/place-review-card/ReviewCard.tsx
@@ -30,7 +30,7 @@ const ReviewCard = ({ review, placeId }: ReviewCardProps) => {
   );
 
   const contentRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
+  const checkContentLines = () => {
     if (contentRef.current) {
       const style = window.getComputedStyle(contentRef.current);
       const lineHeight = parseFloat(style.lineHeight);
@@ -38,7 +38,16 @@ const ReviewCard = ({ review, placeId }: ReviewCardProps) => {
 
       setIsContentLong(lines > 3);
     }
+  };
+  useEffect(() => {
+    checkContentLines();
   }, [review.content]);
+  useEffect(() => {
+    window.addEventListener('resize', checkContentLines);
+    return () => {
+      window.removeEventListener('resize', checkContentLines);
+    };
+  }, []);
 
   const formatDate = (dateString: string) => {
     try {

--- a/src/features/placeDetail/place-review-card/ReviewCard.tsx
+++ b/src/features/placeDetail/place-review-card/ReviewCard.tsx
@@ -1,6 +1,6 @@
 import type { Review } from '../../../types/type';
 import TagButton from '../../../components/share/TagButton';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import LightboxViewer from '../LightboxViewer';
 import LoginModal from '../../login/components/LoginModal';
 import LoginWidget from '../../login/components/LoginWidget';
@@ -18,7 +18,7 @@ const ReviewCard = ({ review, placeId }: ReviewCardProps) => {
   const [index, setIndex] = useState(0);
   const [isLightboxOpen, setIsLightboxOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const isContentLong = review.content.length > 150;
+  const [isContentLong, setIsContentLong] = useState(false);
   const { isLoggedIn } = useAuth();
   const [isLoginOpen, setIsLoginOpen] = useState(false);
 
@@ -28,6 +28,17 @@ const ReviewCard = ({ review, placeId }: ReviewCardProps) => {
     review.liked,
     review.likeCount,
   );
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (contentRef.current) {
+      const style = window.getComputedStyle(contentRef.current);
+      const lineHeight = parseFloat(style.lineHeight);
+      const lines = Math.round(contentRef.current.scrollHeight / lineHeight);
+
+      setIsContentLong(lines > 3);
+    }
+  }, [review.content]);
 
   const formatDate = (dateString: string) => {
     try {
@@ -104,16 +115,18 @@ const ReviewCard = ({ review, placeId }: ReviewCardProps) => {
           </div>
         )}
         <div
+          ref={contentRef}
           className={`whitespace-pre-wrap ${!isExpanded ? 'line-clamp-3' : ''}`}
         >
           {review.content}
         </div>
+
         {isContentLong && (
           <button
             onClick={() => setIsExpanded(!isExpanded)}
             className="-mt-2 text-left text-sm font-semibold text-gray-500"
           >
-            {isExpanded ? '간락히보기' : '더보기...'}
+            {isExpanded ? '간락히 보기' : '더보기...'}
           </button>
         )}
         <div className="flex gap-1 overflow-x-auto whitespace-nowrap">

--- a/src/hooks/useReviewStats.ts
+++ b/src/hooks/useReviewStats.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
-import type { ReviewStatsProps } from '../types/type';
+import type { ReviewStats } from '../types/type';
 import { getReviewStats } from '../features/placeDetail/apis/reviewApi';
 import axios from 'axios';
 import { toast } from 'react-toastify';
 
 export const useReviewStats = (id: string) => {
-  const [stats, setStats] = useState<ReviewStatsProps | null>(null);
+  const [stats, setStats] = useState<ReviewStats | null>(null);
 
   useEffect(() => {
     const fetchPlaceReviewStats = async () => {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -82,7 +82,7 @@ export type Review = {
   tags: { tagId: number; tagName: string }[];
 };
 
-export type ReviewStatsProps = {
+export type ReviewStats = {
   reviewCount: number;
   averageRate: number;
   ratingDistribution: {


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 전체적인 정렬 수정 (items-center)
- [x] 카테고리 출력하는 부분 map으로 출력
- [x] 리뷰더보기 버튼 수정
- [x] 리뷰 내 내용 길어지면 더보기 버튼 하도록 해놨는데 데스크탑 사이즈에서만 가능하고 화면 작아지면 안돼서 이 부분 수정
- [x] 상세 페이지 내 이미지에 hover시 scale 확대해서 클릭 가능함을 좀 더 어필
- [x] 반응형 진행 
      -> 전체화면은 태블릿 이하는 full, 이상은 lg만큼
      -> 리뷰섹션은 태블릿 이하는 full, 이상은 90%만큼
      -> 지도 바로가기 태블릿 이하는 세줄로, 이상은 한줄로

### 📋 주요 변경사항 (Key Changes)

위 작업 내용 확인

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#69]
- **관련 이슈**: [#69 ]

---

### 📸 스크린샷 (Screenshot)


https://github.com/user-attachments/assets/14cd2de3-46e4-4112-993c-5f378f81e8de


---

### ✅ 참고 사항 (Remarks)
