### PR TITLE
fix: main page to explore page error fix

### DIFF
--- a/src/features/explore/components/CategoryFilter.tsx
+++ b/src/features/explore/components/CategoryFilter.tsx
@@ -6,9 +6,6 @@ import { useSearchParams } from 'react-router-dom';
 const CategoryFilter = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const categoryName = searchParams.get('category');
-  const [selectedCategory, setSelectedCategory] = useState(
-    categoryName || '전체',
-  );
   const [categories, setCategories] = useState<CategoryProps[]>([]);
 
   useEffect(() => {
@@ -24,16 +21,11 @@ const CategoryFilter = () => {
     fetchCategory();
   }, []);
 
-  useEffect(() => {
-    setSelectedCategory(categoryName || '전체');
-  }, [categoryName]);
-
   const isSelected = (category: CategoryProps) => {
-    return selectedCategory === category.categoryName;
+    return categoryName === category.categoryName;
   };
 
   const handleCategoryClick = (category: CategoryProps) => {
-    setSelectedCategory(category.categoryName);
     setSearchParams({ category: category.categoryName });
   };
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -42,7 +42,7 @@ const MainPage = () => {
         <Banner />
         <div className="flex justify-center gap-5 pt-10">
           <PageRouterButton
-            to={`/explore`}
+            to={`/explore?category=${'전체'}`}
             icon="/asset/pageRouterButton/allItemIcon.svg"
           >
             <div>전체</div>


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 메인페이지에서 '전체'버튼 클릭 시 탐색페이지로 넘어가서 아무데이터도 뜨지 않는 오류 해결
- [x] 탐색페이지내의 카테고리필터 관련 코드 수정

### 📋 주요 변경사항 (Key Changes)

- 기존에 메인페이지에서 ` to={`/explore`}` 이렇게 보내서 탐색페이지에서
 ```
useEffect(() => {
    setSelectedCategory(categoryName || '전체');
  }, [categoryName]);
```
이렇게 해서 '전체'라고 넣고자 했던 것 같은데 이때 url에 'category=' 라는게 적혀있고 그 상황에서 null 로 왔을때는 '전체'로 초기화를 하지만 '/explore' 이렇게만 보내면 이를 인지하지 못한다고 합니다. 그래서 어쩔수없이 전체에 대해서는 메인페이지에서 '전체' 텍스트 자체로 넣어두었습니다. 

- 또한 관려해서 확인을 해보니 기존에 카테고리 필터에서 selecteCategory를 useState로 관리하고 categoryName를 searchParams로 관리하고 있어서 같은 변수인데 이중으로 관리하고 있는 것을 확인하여 이를 수정했습니다.
---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: [#88 ]
- **관련 이슈**: [#88 ]

---

### 📸 스크린샷 (Screenshot)

https://github.com/user-attachments/assets/f22942a1-230e-49fd-9bea-df2f06dc4d7f

---

### ✅ 참고 사항 (Remarks)
호옥시 그렇게 관리했던 이유가 있으면 말해주세요...!! 다시 돌려두겠습니다
