### PR TITLE
refactor: 장소 상세 페이지에 보이는 리뷰 프리뷰 개수를 2개에서 5개로 증가

### DIFF
--- a/src/features/placeDetail/MoreReviewButton.tsx
+++ b/src/features/placeDetail/MoreReviewButton.tsx
@@ -14,7 +14,7 @@ const MoreReviewButton = ({ reviewCount }: ReviewStatsProps) => {
         onClick={() => navigate(`/detail/${id}/reviews`)}
         className="mb-10 cursor-pointer rounded-xl border border-[#8BE34A] bg-[#77db30] px-6 py-3 font-semibold text-white hover:bg-[#8BE34A]"
       >
-        더 많은 리뷰 보러가기 (+{reviewCount - 2})
+        더 많은 리뷰 보러가기 (+{reviewCount - 5})
       </a>
     </div>
   );

--- a/src/features/placeDetail/PlaceDetailContainer.tsx
+++ b/src/features/placeDetail/PlaceDetailContainer.tsx
@@ -25,7 +25,7 @@ const PlaceDetailContainer = () => {
       <div className="flex w-full border border-gray-100" />
       <ReviewStatsSection stats={stats} />
       <div className="flex w-full flex-col sm:w-[90%]">
-        {reviews.slice(0, 2).map((review) => (
+        {reviews.slice(0, 5).map((review) => (
           <div key={review.reviewId}>
             <div className="flex w-full border border-gray-100" />
             <ReviewCard
@@ -35,7 +35,7 @@ const PlaceDetailContainer = () => {
             />
           </div>
         ))}
-        {reviews.length > 2 && (
+        {reviews.length > 5 && (
           <MoreReviewButton reviewCount={stats.reviewCount} />
         )}
       </div>


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- 장소 상세 페이지에서 보이는 리뷰의 개수가 적다는 의견을 반영하여 5개까지 띄워주는 것으로 수정했습니다.

### 📋 주요 변경사항 (Key Changes)

- 장소 상세 페이지에서 보이는 리뷰의 개수가 적다는 의견을 반영하여 5개까지 띄워주는 것으로 수정했습니다.
---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: #203 

---

### 📸 스크린샷 (Screenshot)

<img width="337" height="703" alt="image" src="https://github.com/user-attachments/assets/2fa41fb9-c007-4d29-9d08-e2ca67fbc9ba" />

---

### ✅ 참고 사항 (Remarks)

- 리뷰 시 특별히 확인해주었으면 하는 부분
- 기술적인 결정에 대한 이유
- ...