### PR TITLE
feat: 제휴맵 페이지에 카테고리 버튼 추가

### DIFF
--- a/src/components/map/KaKaoMapView.tsx
+++ b/src/components/map/KaKaoMapView.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { usePartnershipPlacesForMap } from '../../features/map/hooks/usePartnershipPlacesForMap';
 import { ICONS } from '../../features/share/constants/icons';
 import { PartnershipPlaceCard } from './PartnershipPlaceCard';
+import MapCategorySelector from './MapCategorySelector';
 import type { PlaceProps } from '../../types/type';
 import Spinner from '../share/Spinner';
 
@@ -53,8 +54,10 @@ export default function KakaoMapView({
   const clustererRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
 
+  const [selectedCategory, setSelectedCategory] = useState('전체');
+
   const navigate = useNavigate();
-  const { data: places } = usePartnershipPlacesForMap();
+  const { data: places } = usePartnershipPlacesForMap(selectedCategory);
   const pinImage = ICONS.greenPin;
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<PlaceProps | null>(null);
@@ -234,6 +237,10 @@ export default function KakaoMapView({
           <Spinner />
         </div>
       )}
+      <MapCategorySelector
+        selectedCategory={selectedCategory}
+        onSelect={setSelectedCategory}
+      />
       {selectedPlace && (
         <PartnershipPlaceCard isSheetOpen={isSheetOpen} place={selectedPlace} />
       )}

--- a/src/components/map/MapCategorySelector.tsx
+++ b/src/components/map/MapCategorySelector.tsx
@@ -1,0 +1,55 @@
+import type { CategoryProps } from '../../types/type';
+import { useCategoryLists } from '../../features/explore/hooks/queries';
+
+type Props = {
+  selectedCategory: string;
+  onSelect: (categoryName: string) => void;
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  전체: '/asset/pageRouterButton/allItemIcon.svg',
+  '생활/문화': '/asset/pageRouterButton/lifeIcon.svg',
+  쇼핑: '/asset/pageRouterButton/shoppingIcon.svg',
+  식당: '/asset/pageRouterButton/restaurantIcon.svg',
+  여가: '/asset/pageRouterButton/leisureIcon.svg',
+  카페: '/asset/pageRouterButton/cafeIcon.svg',
+};
+
+export default function MapCategorySelector({
+  selectedCategory,
+  onSelect,
+}: Props) {
+  const { data: categories } = useCategoryLists();
+
+  if (!categories) return null;
+
+  return (
+    <div className="fixed top-23 left-1/2 z-50 flex -translate-x-1/2 gap-2 overflow-y-auto">
+      {categories.map((category: CategoryProps) => {
+        const isSelected = selectedCategory === category.categoryName;
+        const iconSrc = CATEGORY_ICONS[category.categoryName];
+        return (
+          <button
+            key={category.categoryId}
+            onClick={() => onSelect(category.categoryName)}
+            className={`flex h-10 w-10 cursor-pointer flex-col items-center justify-center rounded-full shadow-md transition-all active:scale-95 ${
+              isSelected ? 'bg-[#8BE34A] text-white' : 'bg-white text-gray-700'
+            }`}
+          >
+            {iconSrc ? (
+              <img
+                src={iconSrc}
+                alt={category.categoryName}
+                className="h-5 w-5"
+              />
+            ) : (
+              <span className="text-xs font-semibold">
+                {category.categoryName}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/map/MapCategorySelector.tsx
+++ b/src/components/map/MapCategorySelector.tsx
@@ -24,7 +24,7 @@ export default function MapCategorySelector({
   if (!categories) return null;
 
   return (
-    <div className="fixed top-23 left-1/2 z-50 flex -translate-x-1/2 gap-2">
+    <div className="fixed top-23 left-1/2 z-50 flex -translate-x-1/2 gap-2 sm:top-27">
       {categories.map((category: CategoryProps) => {
         const isSelected = selectedCategory === category.categoryName;
         const iconSrc = CATEGORY_ICONS[category.categoryName];
@@ -32,23 +32,22 @@ export default function MapCategorySelector({
           <button
             key={category.categoryId}
             onClick={() => onSelect(category.categoryName)}
-            className={`flex h-10 w-10 cursor-pointer flex-col items-center justify-center rounded-full shadow-md transition-all active:scale-95 ${
+            className={`flex h-10 w-10 cursor-pointer flex-col items-center justify-center rounded-full shadow-md transition-all active:scale-95 sm:h-auto sm:w-auto sm:flex-row sm:gap-1.5 sm:rounded-full sm:px-5 sm:py-2.5 ${
               isSelected
-                ? 'border-[#7cd23f] bg-[#8BE34A] text-white'
+                ? 'border-[#7cd23f] bg-[#8BE34A]'
                 : 'border-gray-100 bg-white text-gray-700 backdrop-blur-xl'
             }`}
           >
-            {iconSrc ? (
+            {iconSrc && (
               <img
                 src={iconSrc}
                 alt={category.categoryName}
                 className="h-5 w-5"
               />
-            ) : (
-              <span className="text-xs font-semibold">
-                {category.categoryName}
-              </span>
             )}
+            <span className="hidden text-xs font-semibold whitespace-nowrap sm:inline">
+              {category.categoryName}
+            </span>
           </button>
         );
       })}

--- a/src/components/map/MapCategorySelector.tsx
+++ b/src/components/map/MapCategorySelector.tsx
@@ -24,7 +24,7 @@ export default function MapCategorySelector({
   if (!categories) return null;
 
   return (
-    <div className="fixed top-23 left-1/2 z-50 flex -translate-x-1/2 gap-2 overflow-y-auto">
+    <div className="fixed top-23 left-1/2 z-50 flex -translate-x-1/2 gap-2">
       {categories.map((category: CategoryProps) => {
         const isSelected = selectedCategory === category.categoryName;
         const iconSrc = CATEGORY_ICONS[category.categoryName];
@@ -33,7 +33,9 @@ export default function MapCategorySelector({
             key={category.categoryId}
             onClick={() => onSelect(category.categoryName)}
             className={`flex h-10 w-10 cursor-pointer flex-col items-center justify-center rounded-full shadow-md transition-all active:scale-95 ${
-              isSelected ? 'bg-[#8BE34A] text-white' : 'bg-white text-gray-700'
+              isSelected
+                ? 'border-[#7cd23f] bg-[#8BE34A] text-white'
+                : 'border-gray-100 bg-white text-gray-700 backdrop-blur-xl'
             }`}
           >
             {iconSrc ? (

--- a/src/features/map/hooks/usePartnershipPlacesForMap.ts
+++ b/src/features/map/hooks/usePartnershipPlacesForMap.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchFilteredPlaces } from '../../explore/apis/placeApi';
 import { queryKeys } from '../../../lib/query/queryKeys';
 
-export const usePartnershipPlacesForMap = () => {
+export const usePartnershipPlacesForMap = (categoryName: string = '전체') => {
   return useQuery({
-    queryKey: queryKeys.places.partnershipMap(),
-    queryFn: () => fetchFilteredPlaces('전체', [], true, 0, 1000),
+    queryKey: queryKeys.places.partnershipMapByCategory(categoryName),
+    queryFn: () => fetchFilteredPlaces(categoryName, [], true, 0, 1000),
     select: (data) => {
       return data.data?.places ?? [];
     },

--- a/src/lib/query/queryKeys.ts
+++ b/src/lib/query/queryKeys.ts
@@ -8,6 +8,8 @@ export const queryKeys = {
     hot: () => [...queryKeys.places.all, 'hot'] as const,
     partnershipMap: () =>
       [...queryKeys.places.all, 'map', 'partnership'] as const,
+    partnershipMapByCategory: (category: string) =>
+      [...queryKeys.places.all, 'map', 'partnership', category] as const,
   },
   reviews: {
     all: ['reviews'] as const,


### PR DESCRIPTION
### 🧐 작업 내용 (Task)
- 제휴맵 페이지에 카테고리 버튼 추가

### 📋 주요 변경사항 (Key Changes)

기존에는 usePartnershipPlacesForMap 훅에 '전체' 카테고리를 고정값으로 전달했으나 현재는 MapCategorySelector에서 선택된 카테고리를 파라미터로 동적으로 전달하여 데이터가 실시간으로 필터링되도록 수정했습니다.

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: #202 

---

### 📸 스크린샷 (Screenshot)

- 모바일
<img width="323" height="697" alt="image" src="https://github.com/user-attachments/assets/b35a42e0-8de0-427e-99c3-8175f1b466e6" />

- 데스크탑
<img width="1059" height="796" alt="image" src="https://github.com/user-attachments/assets/f11a0fd7-9f5b-4a05-8e64-26577d474a89" />


---

### ✅ 참고 사항 (Remarks)

- 리뷰 시 특별히 확인해주었으면 하는 부분
- 기술적인 결정에 대한 이유
- ...