### PR TITLE
fix: 모바일에서 서치바의 검색버튼이 잘리거나 보이지 않는 이슈 수정

### DIFF
--- a/src/components/share/SearchBar.tsx
+++ b/src/components/share/SearchBar.tsx
@@ -21,17 +21,17 @@ const SearchBar = () => {
   return (
     <form
       onSubmit={handleSubmit}
-      className="mt-10 flex w-[80%] overflow-hidden rounded-2xl border border-[#8BE34A] lg:w-[60%]"
+      className="mt-10 flex w-[80%] rounded-2xl border border-[#8BE34A] lg:w-[60%]"
     >
       <input
         value={keyword}
         onChange={(e) => setKeyword(e.target.value)}
-        className="flex-1 px-5 py-4 text-sm outline-none lg:text-base"
+        className="flex-1 rounded-l-2xl px-5 py-4 text-sm outline-none lg:text-base"
         placeholder="궁금한 장소를 검색해보세요 !"
       />
       <button
         type="submit"
-        className="flex items-center justify-center bg-[#8BE34A] px-4.5 lg:px-7"
+        className="flex flex-shrink-0 items-center justify-center rounded-r-2xl bg-[#8BE34A] px-4.5 lg:px-7"
       >
         <img src="/asset/searchbar/search.svg" alt="search"></img>
       </button>


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [ ] 모바일에서 서치바의 검색버튼이 잘리거나 보이지 않는 이슈 수정

### 📋 주요 변경사항 (Key Changes)

- 로컬서버에서 개발자모드를 통해 모바일 버전을 볼때는 사실 이상이 없었어서 제대로 해결이 됐는지는 배포 후에 반영된 모습을 보고 확인을 해야할 것 같습니다.
- button에 `flex-shrink-0` 추가하여 버튼이 찌그러지거나 사라지지 않도록 고정하는 방식으로 수정했습니다.

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: #211 

---

### 📸 스크린샷 (Screenshot)

기존에 문제가 됐던 화면입니다. 핸드폰으로 들어가보면 다음과 같이 검색바가 이상합니다 !
<img width="1170" height="2532" alt="IMG_6391" src="https://github.com/user-attachments/assets/64fe7aa2-197f-476b-80ea-cf311924728d" />

현재 수정사항이 반영이 잘 되었을때 기대하는 화면 모습입니다.
<img width="369" height="666" alt="image" src="https://github.com/user-attachments/assets/1bb7aa55-6b53-441d-bc43-f65123fc3103" />


---

### ✅ 참고 사항 (Remarks)

