### PR TITLE
feat: 미팅부스 카카오 로그인 및 백엔드 api 연동

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import MyPlacesPage from './pages/MyPlacesPage';
 import PrivacyPolicy from './pages/PrivacyPolicyPage';
 import KakaoMapPage from './pages/KakaoMapPage';
 import ScrollToTop from './components/share/ScrollToTop';
+import MeetingKakaoLoginPage from './pages/MeetingKaKaoLoginPage';
 
 // lazy import
 const MainPage = lazy(() => import('./pages/MainPage'));
@@ -111,6 +112,10 @@ function App() {
               }
             />
             <Route path="/privacy" element={<PrivacyPolicy />} />
+            <Route
+              path="/meeting/kakaoLogin"
+              element={<MeetingKakaoLoginPage />}
+            />
             <Route path="/meeting" element={<MeetingPage />} />
             <Route path="/meeting/register" element={<MeetingRegisterPage />} />
           </Routes>

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -12,8 +12,22 @@ export const fetchMeetingProfiles = async (): Promise<Profile[]> => {
 
 export const registerMeetingProfile = async (
   payload: ProfileRegisterPayload,
-): Promise<{ id: number; message: string }> => {
-  const response = await authApi.post('/meeting/profiles', payload);
+): Promise<{
+  message: string;
+  data: {
+    accessToken: string;
+    signUpToken: string;
+    userInfo: { studentId: string; name: string };
+    newUser: boolean;
+  };
+}> => {
+  const signUpToken = sessionStorage.getItem('signUpToken');
+
+  const response = await authApi.post('/meeting/auth/signup', payload, {
+    headers: {
+      Authorization: `Bearer ${signUpToken}`,
+    },
+  });
   return response.data;
 };
 

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -34,7 +34,9 @@ export const registerMeetingProfile = async (
 export const openMeetingCard = async (
   profileId: number,
 ): Promise<CardOpenResponse> => {
-  const response = await authApi.post(`/meeting/profiles/${profileId}/open`);
+  const response = await authApi.post(
+    `/api/meeting/profiles/${profileId}/open`,
+  );
   return response.data;
 };
 

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -37,6 +37,7 @@ export const openMeetingCard = async (
   const response = await authApi.post(
     `/api/meeting/profiles/${profileId}/open`,
   );
+  localStorage.removeItem('accessToken');
   return response.data;
 };
 

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -23,7 +23,7 @@ export const registerMeetingProfile = async (
 }> => {
   const signUpToken = sessionStorage.getItem('signUpToken');
 
-  const response = await authApi.post('/meeting/auth/signup', payload, {
+  const response = await authApi.post('/api/meeting/auth/signup', payload, {
     headers: {
       Authorization: `Bearer ${signUpToken}`,
     },

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -1,4 +1,4 @@
-import { authApi } from '../../../api/api';
+import { api, authApi } from '../../../api/api';
 import type {
   Profile,
   ProfileRegisterPayload,
@@ -48,7 +48,7 @@ export const kakaoLogin = async ({
   code: string;
   state: string;
 }) => {
-  const response = await authApi.post('/api/meeting/auth/kakao/login', {
+  const response = await api.post('/api/meeting/auth/kakao/login', {
     code,
     state,
   });

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -37,7 +37,6 @@ export const openMeetingCard = async (
   const response = await authApi.post(
     `/api/meeting/profiles/${profileId}/open`,
   );
-  localStorage.removeItem('accessToken');
   return response.data;
 };
 

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -37,3 +37,17 @@ export const openMeetingCard = async (
   const response = await authApi.post(`/meeting/profiles/${profileId}/open`);
   return response.data;
 };
+
+export const kakaoLogin = async ({
+  code,
+  state,
+}: {
+  code: string;
+  state: string;
+}) => {
+  const response = await authApi.post('/api/meeting/auth/kakao/login', {
+    code,
+    state,
+  });
+  return response.data;
+};

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../../types/meetingType';
 
 export const fetchMeetingProfiles = async (): Promise<Profile[]> => {
-  const response = await authApi.get('/meeting/profiles');
+  const response = await authApi.get('/api/meeting/profiles');
   return response.data;
 };
 

--- a/src/features/meeting/components/BirthYearStep.tsx
+++ b/src/features/meeting/components/BirthYearStep.tsx
@@ -60,9 +60,9 @@ function BirthYearStep({ value, onChange }: BirthYearStepProps) {
   return (
     <div className="flex w-full flex-col items-start gap-1 pb-1">
       <div className="flex w-full flex-col gap-1 pb-1">
-        <h2 className="text-heading-1 text-shark">나이를 알려주세요</h2>
+        <h2 className="text-heading-1 text-shark">당신의 나이는?</h2>
         <p className="text-body-regular text-jumbo">
-          스크롤해서 나이를 선택하세요
+          스크롤해서 출생연도를 선택하세요
         </p>
       </div>
       <div className="flex w-full flex-col items-center gap-3 pt-4">

--- a/src/features/meeting/components/ContactRevealModal.tsx
+++ b/src/features/meeting/components/ContactRevealModal.tsx
@@ -1,25 +1,44 @@
+import { useState, useEffect } from 'react';
+
 interface ContactRevealModalProps {
   contact: string;
-  remainOpenCount: number;
   onClose: () => void;
 }
 
-function ContactRevealModal({
-  contact,
-  remainOpenCount,
-  onClose,
-}: ContactRevealModalProps) {
+function ContactRevealModal({ contact, onClose }: ContactRevealModalProps) {
+  const [countdown, setCountdown] = useState(30);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          onClose();
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(contact);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: 'rgba(0, 0, 0, 0.5)' }}
-      onClick={onClose}
     >
       <div
         role="dialog"
         aria-modal="true"
         aria-labelledby="contact-modal-title"
-        className="relative mx-4 flex w-full max-w-sm flex-col items-center gap-6 rounded-3xl bg-white p-8"
+        className="relative mx-4 flex w-full max-w-sm flex-col items-center gap-5 rounded-3xl bg-white p-8"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex w-full flex-col items-center gap-2">
@@ -30,21 +49,37 @@ function ContactRevealModal({
           >
             연락처가 공개되었어요!
           </h2>
-          <p className="text-body-regular text-jumbo text-center">
-            남은 오픈 횟수: {remainOpenCount}회
+          <p className="text-center text-sm text-gray-400">
+            이 창을 닫으면 다시 볼 수 없어요
+            <br />
+            연락처를 복사하거나 캡처해두세요
           </p>
         </div>
+
         <div className="bg-meeting-surface flex w-full items-center justify-center rounded-2xl px-6 py-4">
           <span className="text-heading-2 text-shark text-center break-all">
             {contact}
           </span>
         </div>
+
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="w-full cursor-pointer rounded-2xl border border-gray-200 py-3 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+        >
+          {copied ? '✅ 복사됐어요!' : '연락처 복사하기'}
+        </button>
+
+        <p className="text-sm text-gray-400">
+          ⏱ {countdown}초 후 자동으로 홈으로 돌아갑니다
+        </p>
+
         <button
           type="button"
           onClick={onClose}
           className="bg-main-gradient text-button w-full cursor-pointer rounded-2xl py-4 font-bold text-white"
         >
-          확인
+          닫기
         </button>
       </div>
     </div>

--- a/src/features/meeting/components/ContactRevealModal.tsx
+++ b/src/features/meeting/components/ContactRevealModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 interface ContactRevealModalProps {
   contact: string;
@@ -6,22 +6,7 @@ interface ContactRevealModalProps {
 }
 
 function ContactRevealModal({ contact, onClose }: ContactRevealModalProps) {
-  const [countdown, setCountdown] = useState(30);
   const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          onClose();
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, []);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(contact);
@@ -50,8 +35,6 @@ function ContactRevealModal({ contact, onClose }: ContactRevealModalProps) {
             연락처가 공개되었어요!
           </h2>
           <p className="text-center text-sm text-gray-400">
-            이 창을 닫으면 다시 볼 수 없어요
-            <br />
             연락처를 복사하거나 캡처해두세요
           </p>
         </div>
@@ -69,10 +52,6 @@ function ContactRevealModal({ contact, onClose }: ContactRevealModalProps) {
         >
           {copied ? '✅ 복사됐어요!' : '연락처 복사하기'}
         </button>
-
-        <p className="text-sm text-gray-400">
-          ⏱ {countdown}초 후 자동으로 홈으로 돌아갑니다
-        </p>
 
         <button
           type="button"

--- a/src/features/meeting/components/FaceTypeStep.tsx
+++ b/src/features/meeting/components/FaceTypeStep.tsx
@@ -1,9 +1,4 @@
-import { FACE_TYPE_EMOJI } from '../constants/meetingConstants';
-
-const FACE_TYPES = Object.entries(FACE_TYPE_EMOJI).map(([label, emoji]) => ({
-  label,
-  emoji,
-}));
+import { FACE_TYPES } from '../constants/meetingConstants';
 
 interface FaceTypeStepProps {
   value: string | null;
@@ -18,20 +13,20 @@ function FaceTypeStep({ value, onChange }: FaceTypeStepProps) {
         <p className="text-body-regular text-jumbo">닮은 동물을 골라주세요</p>
       </div>
       <div className="grid w-full grid-cols-2 gap-4 pt-4">
-        {FACE_TYPES.map(({ label, emoji }) => (
+        {FACE_TYPES.map(({ value: faceValue, label, emoji }) => (
           <button
-            key={label}
+            key={faceValue}
             type="button"
-            onClick={() => onChange(label)}
+            onClick={() => onChange(faceValue)}
             className={`flex h-[120px] cursor-pointer flex-col items-center justify-center gap-2 rounded-3xl border transition-colors ${
-              value === label
+              value === faceValue
                 ? 'bg-main-gradient border-transparent'
                 : 'border-iron hover:border-mandy bg-white'
             }`}
           >
             <span className="text-[46.9px] leading-[48px]">{emoji}</span>
             <span
-              className={`text-body-bold ${value === label ? 'text-white' : 'text-shark'}`}
+              className={`text-body-bold ${value === faceValue ? 'text-white' : 'text-shark'}`}
             >
               {label}
             </span>

--- a/src/features/meeting/components/GenderStep.tsx
+++ b/src/features/meeting/components/GenderStep.tsx
@@ -1,6 +1,6 @@
 interface GenderStepProps {
-  value: '남' | '여' | null;
-  onChange: (gender: '남' | '여') => void;
+  value: 'MALE' | 'FEMALE' | null;
+  onChange: (gender: 'MALE' | 'FEMALE') => void;
 }
 
 function GenderStep({ value, onChange }: GenderStepProps) {
@@ -13,32 +13,32 @@ function GenderStep({ value, onChange }: GenderStepProps) {
       <div className="flex w-full flex-row gap-4 pt-4">
         <button
           type="button"
-          onClick={() => onChange('남')}
+          onClick={() => onChange('MALE')}
           className={`flex h-[163px] flex-1 cursor-pointer flex-col items-center justify-center rounded-3xl border transition-colors ${
-            value === '남'
+            value === 'MALE'
               ? 'bg-main-gradient border-transparent'
               : 'border-iron hover:border-mandy bg-white'
           }`}
         >
           <span className="mb-2 text-[46.9px] leading-[48px]">🙋‍♂️</span>
           <span
-            className={`text-button ${value === '남' ? 'text-white' : 'text-shark'}`}
+            className={`text-button ${value === 'MALE' ? 'text-white' : 'text-shark'}`}
           >
             남성
           </span>
         </button>
         <button
           type="button"
-          onClick={() => onChange('여')}
+          onClick={() => onChange('FEMALE')}
           className={`flex h-[163px] flex-1 cursor-pointer flex-col items-center justify-center rounded-3xl border transition-colors ${
-            value === '여'
+            value === 'FEMALE'
               ? 'bg-main-gradient border-transparent'
               : 'border-iron hover:border-mandy bg-white'
           }`}
         >
           <span className="mb-2 text-[46.9px] leading-[48px]">🙋‍♀️</span>
           <span
-            className={`text-button ${value === '여' ? 'text-white' : 'text-shark'}`}
+            className={`text-button ${value === 'FEMALE' ? 'text-white' : 'text-shark'}`}
           >
             여성
           </span>

--- a/src/features/meeting/components/GenderStep.tsx
+++ b/src/features/meeting/components/GenderStep.tsx
@@ -7,7 +7,7 @@ function GenderStep({ value, onChange }: GenderStepProps) {
   return (
     <div className="flex w-full flex-col items-start gap-1 pb-1">
       <div className="flex w-full flex-col gap-1 pb-1">
-        <h2 className="text-heading-1 text-shark">성별을 선택해주세요</h2>
+        <h2 className="text-heading-1 text-shark">당신의 성별은?</h2>
         <p className="text-body-regular text-jumbo">하나를 선택해주세요</p>
       </div>
       <div className="flex w-full flex-row gap-4 pt-4">

--- a/src/features/meeting/components/MeetingBanner.tsx
+++ b/src/features/meeting/components/MeetingBanner.tsx
@@ -1,4 +1,8 @@
+import { useNavigate } from 'react-router-dom';
+
 const MeetingBanner = () => {
+  const navigate = useNavigate();
+
   return (
     <div className="bg-main-gradient relative mx-4 mt-5 flex items-center justify-between overflow-hidden rounded-2xl p-5">
       <div className="relative z-10">
@@ -16,7 +20,10 @@ const MeetingBanner = () => {
         </p>
       </div>
 
-      <button className="relative z-10 flex-shrink-0 rounded-xl bg-white px-4 py-2.5 text-xs font-bold text-[#f8433a]">
+      <button
+        onClick={() => navigate('/meeting/kakaoLogin')}
+        className="relative z-10 flex-shrink-0 rounded-xl bg-white px-4 py-2.5 text-xs font-bold text-[#f8433a]"
+      >
         참여하기 →
       </button>
     </div>

--- a/src/features/meeting/components/MeetingBanner.tsx
+++ b/src/features/meeting/components/MeetingBanner.tsx
@@ -10,7 +10,7 @@ const MeetingBanner = () => {
           ✨ 축제 한정
         </span>
         <p className="text-[17px] leading-snug font-extrabold text-white">
-          캠퍼스 미팅부스 OPEN!
+          슬기로운 연애생활 OPEN!
         </p>
         <p className="mt-1 text-[11px] text-white/80">
           축제 기간 동안 운영되는 특별한 만남의 공간

--- a/src/features/meeting/components/MeetingBanner.tsx
+++ b/src/features/meeting/components/MeetingBanner.tsx
@@ -1,0 +1,26 @@
+const MeetingBanner = () => {
+  return (
+    <div className="bg-main-gradient relative mx-4 mt-5 flex items-center justify-between overflow-hidden rounded-2xl p-5">
+      <div className="relative z-10">
+        <span className="mb-2 inline-block rounded-full bg-white/20 px-3 py-0.5 text-[11px] font-bold text-white">
+          ✨ 축제 한정
+        </span>
+        <p className="text-[17px] leading-snug font-extrabold text-white">
+          캠퍼스 미팅부스 OPEN!
+        </p>
+        <p className="mt-1 text-[11px] text-white/80">
+          축제 기간 동안 운영되는 특별한 만남의 공간
+        </p>
+        <p className="mt-1 text-[10px] text-white/60">
+          🕐 2026. 05. 20 (수) ~ 05. 22 (일)
+        </p>
+      </div>
+
+      <button className="relative z-10 flex-shrink-0 rounded-xl bg-white px-4 py-2.5 text-xs font-bold text-[#f8433a]">
+        참여하기 →
+      </button>
+    </div>
+  );
+};
+
+export default MeetingBanner;

--- a/src/features/meeting/components/MeetingInfoCard.tsx
+++ b/src/features/meeting/components/MeetingInfoCard.tsx
@@ -1,0 +1,23 @@
+export const MeetingInfoCard = ({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: React.ReactNode;
+  description: string;
+}) => {
+  return (
+    <div className="flex w-full items-center gap-4 rounded-[10px] bg-white/85 p-5 shadow-[0_12px_40px_rgba(31,41,55,0.08)] backdrop-blur-md">
+      <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-orange-50 text-3xl">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className="font-extrabold text-gray-900">{title}</p>
+        <p className="mt-1 text-xs leading-relaxed text-gray-600">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/features/meeting/components/ProfileCard.tsx
+++ b/src/features/meeting/components/ProfileCard.tsx
@@ -4,9 +4,10 @@ import { CURRENT_YEAR, FACE_TYPES } from '../constants/meetingConstants';
 interface ProfileCardProps {
   profile: Profile;
   onOpen: (profileId: number) => void;
+  isOpening: boolean;
 }
 
-function ProfileCard({ profile, onOpen }: ProfileCardProps) {
+function ProfileCard({ profile, onOpen, isOpening }: ProfileCardProps) {
   const faceType = FACE_TYPES.find((f) => f.value === profile.faceType);
   const emoji = faceType?.emoji ?? '😊';
   const faceLabel = faceType?.label ?? profile.faceType;
@@ -20,7 +21,8 @@ function ProfileCard({ profile, onOpen }: ProfileCardProps) {
     <button
       type="button"
       onClick={() => onOpen(profile.id)}
-      className="bg-card-gradient isolation-isolate relative flex w-full cursor-pointer flex-col items-start overflow-hidden rounded-3xl p-5 text-left"
+      disabled={isOpening}
+      className="bg-card-gradient isolation-isolate relative flex w-full cursor-pointer flex-col items-start overflow-hidden rounded-3xl p-5 text-left disabled:cursor-not-allowed disabled:opacity-50"
     >
       <div
         className="pointer-events-none absolute"

--- a/src/features/meeting/components/ProfileCard.tsx
+++ b/src/features/meeting/components/ProfileCard.tsx
@@ -1,5 +1,5 @@
 import type { Profile } from '../../../types/meetingType';
-import { CURRENT_YEAR, FACE_TYPE_EMOJI } from '../constants/meetingConstants';
+import { CURRENT_YEAR, FACE_TYPES } from '../constants/meetingConstants';
 
 interface ProfileCardProps {
   profile: Profile;
@@ -7,7 +7,9 @@ interface ProfileCardProps {
 }
 
 function ProfileCard({ profile, onOpen }: ProfileCardProps) {
-  const emoji = FACE_TYPE_EMOJI[profile.faceType] ?? '😊';
+  const faceType = FACE_TYPES.find((f) => f.value === profile.faceType);
+  const emoji = faceType?.emoji ?? '😊';
+  const faceLabel = faceType?.label ?? profile.faceType;
   const age = CURRENT_YEAR - profile.birthYear;
   const hobbyTags = profile.hobby
     .split(',')
@@ -64,7 +66,7 @@ function ProfileCard({ profile, onOpen }: ProfileCardProps) {
           </div>
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="text-button text-shark leading-6">
-              {profile.faceType}
+              {faceLabel}
             </span>
             <span className="text-body-regular text-jumbo">{age}세</span>
           </div>
@@ -83,7 +85,7 @@ function ProfileCard({ profile, onOpen }: ProfileCardProps) {
             Q: 함께하고 싶은 데이트는?
           </span>
           <span className="text-body-medium text-shark">
-            &quot;{profile.desiredDate}&quot;
+            &quot;{profile.dateStyle}&quot;
           </span>
         </div>
         {hobbyTags.length > 0 && (

--- a/src/features/meeting/components/ProfileCardList.tsx
+++ b/src/features/meeting/components/ProfileCardList.tsx
@@ -4,14 +4,23 @@ import ProfileCard from './ProfileCard';
 interface ProfileCardListProps {
   profiles: Profile[];
   onOpenCard: (profileId: number) => void;
+  isOpening: boolean;
 }
 
-function ProfileCardList({ profiles, onOpenCard }: ProfileCardListProps) {
+function ProfileCardList({
+  profiles,
+  onOpenCard,
+  isOpening,
+}: ProfileCardListProps) {
   return (
     <ul className="flex w-full flex-col gap-5 px-4 pt-2 pb-8">
       {profiles.map((profile) => (
         <li key={profile.id}>
-          <ProfileCard profile={profile} onOpen={onOpenCard} />
+          <ProfileCard
+            profile={profile}
+            onOpen={onOpenCard}
+            isOpening={isOpening}
+          />
         </li>
       ))}
     </ul>

--- a/src/features/meeting/components/TextareaStep.tsx
+++ b/src/features/meeting/components/TextareaStep.tsx
@@ -6,6 +6,7 @@ interface TextareaStepProps {
   placeholder: string;
   value: string;
   onChange: (value: string) => void;
+  maxLength?: number;
 }
 
 function TextareaStep({
@@ -14,6 +15,7 @@ function TextareaStep({
   placeholder,
   value,
   onChange,
+  maxLength = 100,
 }: TextareaStepProps) {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (event.target.value.length <= MAX_LENGTH) {
@@ -41,7 +43,7 @@ function TextareaStep({
           </div>
           <div className="mt-1 flex justify-end">
             <span className="text-char-count text-[#B9B9B9]">
-              {value.length}/{MAX_LENGTH}
+              {value.length}/{maxLength}
             </span>
           </div>
         </div>

--- a/src/features/meeting/constants/meetingConstants.ts
+++ b/src/features/meeting/constants/meetingConstants.ts
@@ -1,12 +1,12 @@
 export const CURRENT_YEAR = new Date().getFullYear();
 
-export const FACE_TYPE_EMOJI: Record<string, string> = {
-  강아지상: '🐶',
-  고양이상: '🐱',
-  여우상: '🦊',
-  토끼상: '🐰',
-  곰상: '🐻',
-  사슴상: '🦌',
-  햄스터상: '🐹',
-  공룡상: '🦕',
-};
+export const FACE_TYPES: { value: string; label: string; emoji: string }[] = [
+  { value: 'DOG', label: '강아지상', emoji: '🐶' },
+  { value: 'CAT', label: '고양이상', emoji: '🐱' },
+  { value: 'FOX', label: '여우상', emoji: '🦊' },
+  { value: 'RABBIT', label: '토끼상', emoji: '🐰' },
+  { value: 'BEAR', label: '곰상', emoji: '🐻' },
+  { value: 'DEER', label: '사슴상', emoji: '🦌' },
+  { value: 'HAMSTER', label: '햄스터상', emoji: '🐹' },
+  { value: 'DINOSAUR', label: '공룡상', emoji: '🦕' },
+];

--- a/src/features/meeting/hooks/useKakaoLogin.ts
+++ b/src/features/meeting/hooks/useKakaoLogin.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { kakaoLogin } from '../apis/meetingApi';
+import { toast } from 'react-toastify';
+
+export const useKakaoLogin = (onSuccess: (data: any) => void) => {
+  return useMutation({
+    mutationFn: ({ code, state }: { code: string; state: string }) =>
+      kakaoLogin({ code, state }),
+    onSuccess,
+    onError: () => {
+      toast.error('로그인에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/features/meeting/hooks/useRegisterProfile.ts
+++ b/src/features/meeting/hooks/useRegisterProfile.ts
@@ -12,7 +12,9 @@ export const useRegisterProfile = () => {
   return useMutation({
     mutationFn: (payload: ProfileRegisterPayload) =>
       registerMeetingProfile(payload),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      localStorage.setItem('accessToken', data.data.accessToken);
+      sessionStorage.removeItem('signUpToken');
       toast.success('프로필이 등록되었습니다!');
       queryClient.invalidateQueries({ queryKey: queryKeys.meeting.profiles() });
       navigate('/meeting');

--- a/src/features/meeting/mock/meetingMockProfiles.ts
+++ b/src/features/meeting/mock/meetingMockProfiles.ts
@@ -1,0 +1,49 @@
+import type { Profile } from '../../../types/meetingType';
+
+export const meetingMockProfiles: (Profile & { position: string })[] = [
+  {
+    id: 1,
+    faceType: 'DOG',
+    gender: 'FEMALE',
+    birthYear: 2004,
+    dateStyle: '맛집 탐방과 산책 데이트',
+    hobby: '여행, 사진찍기, 요리',
+    position: 'left-[8px] top-[24px] -rotate-12',
+  },
+  {
+    id: 2,
+    faceType: 'CAT',
+    gender: 'FEMALE',
+    birthYear: 2005,
+    dateStyle: '전시회, 영화, 그리고 와인 한 잔',
+    hobby: '영화, 독서, 러닝',
+    position: 'right-[-18px] top-[88px] rotate-12',
+  },
+  {
+    id: 3,
+    faceType: 'HAMSTER',
+    birthYear: 2001,
+    dateStyle: '애버랜드',
+    gender: 'MALE',
+    hobby: '쇼핑, 음악 듣기',
+    position: 'left-[-28px] top-[260px] rotate-6',
+  },
+  {
+    id: 4,
+    faceType: 'DINOSOUR',
+    birthYear: 1998,
+    gender: 'MALE',
+    dateStyle: '카페에서 수다 떨기',
+    hobby: '카페, 산책',
+    position: 'right-[-34px] top-[390px] -rotate-6',
+  },
+  {
+    id: 5,
+    faceType: 'DEER',
+    birthYear: 2002,
+    gender: 'FEMALE',
+    dateStyle: '전시회, 영화 한 편',
+    hobby: '독서, 러닝',
+    position: 'left-[120px] top-[170px] rotate-2',
+  },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,9 @@ import App from './App.tsx';
 import './index.css';
 
 async function enableMocking() {
-  if (!import.meta.env.DEV) return;
-  const { worker } = await import('./mock/browser');
-  return worker.start({ onUnhandledRequest: 'bypass' });
+  //   if (!import.meta.env.DEV) return;
+  //   const { worker } = await import('./mock/browser');
+  //   return worker.start({ onUnhandledRequest: 'bypass' });
 }
 
 enableMocking().then(() => {

--- a/src/mock/handler/MeetingEndpoints.ts
+++ b/src/mock/handler/MeetingEndpoints.ts
@@ -9,7 +9,8 @@ const mockProfiles = [
     faceType: '고양이상',
     birthYear: 2001,
     hobby: '독서, 요가',
-    desiredDate: '카페에서 조용한 대화',
+    desiredDate:
+      '집에서 같이 요리하기 성수동 팝업스토어 오픈런 같이하기 한강에서 자전거타기',
     selfAppeal: '조용하고 감성적인 편이에요',
     remainPickCount: 5,
   },

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -8,6 +8,7 @@ import { useHotPlaces } from '../features/main/hooks';
 import SearchBar from '../components/share/SearchBar';
 import { useNavigate } from 'react-router-dom';
 import MapNavigateButton from '../components/share/MapNavigateButton';
+import MeetingBanner from '../features/meeting/components/MeetingBanner';
 
 const menus = [
   {
@@ -59,6 +60,7 @@ const MainPage = () => {
   return (
     <>
       <div className="w-full overflow-x-hidden">
+        <MeetingBanner />
         <Banner />
         <div className="flex justify-center">
           <SearchBar />

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -2,6 +2,9 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import { useKakaoLogin } from '../features/meeting/hooks/useKakaoLogin';
 import { authApi } from '../api/api';
+import { MeetingInfoCard } from '../features/meeting/components/MeetingInfoCard';
+import ProfileCard from '../features/meeting/components/ProfileCard';
+import { meetingMockProfiles } from '../features/meeting/mock/meetingMockProfiles';
 
 const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
 const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
@@ -9,6 +12,7 @@ const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 const MeetingKakaoLoginPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+
   const { mutate: kakaoLogin } = useKakaoLogin((data) => {
     if (data.data.newUser) {
       sessionStorage.setItem('signUpToken', data.data.signUpToken);
@@ -24,11 +28,12 @@ const MeetingKakaoLoginPage = () => {
   useEffect(() => {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
+
     if (code && state && !hasCalledLogin.current) {
       hasCalledLogin.current = true;
       kakaoLogin({ code, state });
     }
-  }, []);
+  }, [searchParams, kakaoLogin]);
 
   const handleKakaoLogin = async () => {
     const { data } = await authApi.get('/api/meeting/auth/kakao/state');
@@ -40,42 +45,119 @@ const MeetingKakaoLoginPage = () => {
       `&response_type=code` +
       `&state=${encodeURIComponent(data.data.state)}`;
   };
+
   return (
-    <main className="bg-alabaster mx-auto flex min-h-screen w-full max-w-[448px] flex-col items-center justify-center px-6">
-      <div className="mb-12 flex flex-col items-center gap-2 text-center">
-        <h1 className="text-2xl font-bold text-gray-900">미팅 서비스</h1>
-        <p className="font-semibold text-gray-900">
-          카카오 로그인 후 이용할 수 있어요
-        </p>
-        <div className="mt-1 flex items-center gap-1 rounded-lg bg-gray-100 px-3 py-1.5">
-          <span className="text-xs text-gray-500">
-            📱 모바일 이용을 권장해요
-          </span>
-        </div>
+    <main className="relative mx-auto min-h-screen w-full max-w-[448px] overflow-hidden bg-[#FFFDF9]">
+      <style>
+        {`
+          @keyframes floatUp {
+            0% {
+              transform: translateY(70px) scale(1);
+            }
+            100% {
+              transform: translateY(-70px) scale(1);
+            }
+          }
+        `}
+      </style>
+
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,#FFE4D2_0%,#FFFDF9_48%,#FFFFFF_100%)]" />
+
+      <div className="pointer-events-none absolute inset-0 opacity-60 blur-[1px]">
+        {meetingMockProfiles.map((profile, index) => (
+          <div
+            key={profile.id}
+            className={`absolute ${profile.position} w-[210px] rounded-2xl shadow-[0_8px_32px_rgba(255,107,53,0.2)] ring-1 ring-orange-200`}
+            style={{
+              animation: 'floatUp 12s linear infinite',
+              animationDelay: `${index * -2}s`,
+            }}
+          >
+            <ProfileCard
+              profile={profile}
+              onOpen={() => {}}
+              isOpening={false}
+            />
+          </div>
+        ))}
       </div>
 
-      <button
-        onClick={handleKakaoLogin}
-        className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl py-4 font-bold text-[#3C1E1E]"
-        style={{ backgroundColor: '#FEE500' }}
-      >
-        카카오로 시작하기
-      </button>
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/10 via-white/70 to-white" />
 
-      <div className="mt-6 flex w-full flex-col items-center gap-2">
-        <div className="flex items-start gap-2">
-          <span className="mt-0.5 text-xs text-gray-400">🔒</span>
-          <p className="text-xs leading-relaxed text-gray-400">
-            카카오 계정은 로그인 인증용으로만 사용돼요
-          </p>
+      <section className="relative z-10 flex min-h-screen flex-col px-6 pt-10 pb-7">
+        <div className="flex-1">
+          <div className="mt-20 text-center">
+            <h1 className="text-[32px] leading-tight font-black tracking-[-0.04em] text-gray-900">
+              내 카드를 등록하면
+              <br />
+              <span className="text-[#FF6B35]">인연 카드를 뽑을 수 있어요</span>
+            </h1>
+            <p className="mt-3 text-base leading-relaxed font-medium text-gray-500">
+              등록은 딱 한 번, 카드는 축제 기간 동안 유지돼요
+            </p>
+          </div>
+
+          <div className="mt-5 flex items-center justify-center gap-3">
+            <span className="text-sm font-semibold text-[#FF5F6D]">
+              ♀ 여자 999명
+            </span>
+            <span className="h-3.5 w-px bg-gray-200" />
+            <span className="text-sm font-semibold text-[#3B82F6]">
+              ♂ 남자 999명
+            </span>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-2">
+            <MeetingInfoCard
+              icon="🎟️"
+              title={
+                <>
+                  <span className="text-[#FF6B35]">등록</span>하면 바로{' '}
+                  <span className="text-[#FF6B35]">1회</span> 열람
+                </>
+              }
+              description="내 카드를 등록하면 다른 사람의 카드를 1번 뽑을 수 있어요."
+            />
+
+            <MeetingInfoCard
+              icon="⏰"
+              title={
+                <>
+                  <span className="text-[#FF6B35]">1시간마다</span> 뽑기 기회{' '}
+                  <span className="text-[#FF6B35]">+1</span>
+                </>
+              }
+              description="카드를 뽑은 후 1시간마다 +1의 뽑기 기회가 생겨요. 자주 방문할수록 더 많은 인연을!"
+            />
+
+            <MeetingInfoCard
+              icon="🔗"
+              title={
+                <>
+                  <span className="text-[#FF6B35]">링크 공유</span>하면 뽑기
+                  기회 <span className="text-[#FF6B35]"> +1</span>
+                </>
+              }
+              description="친구에게 슬종생 링크를 공유하면 추가로 뽑기 기회를 받을 수 있어요."
+            />
+          </div>
         </div>
-        <div className="flex gap-2">
-          <span className="mt-0.5 text-xs text-gray-400">❌</span>
-          <p className="text-xs leading-relaxed text-gray-400">
-            이름, 친구목록 등 개인정보는 일절 수집하지 않아요
-          </p>
+
+        <div className="fixed bottom-0 left-1/2 w-full max-w-[448px] -translate-x-1/2 bg-gradient-to-t from-white via-white to-transparent px-2 pt-4 pb-8">
+          <button
+            type="button"
+            onClick={handleKakaoLogin}
+            className="flex w-full cursor-pointer items-center justify-center gap-4 rounded-full bg-gradient-to-r from-[#FF6B35] to-[#FF5F6D] py-4 text-center leading-tight font-bold text-white shadow-[0_16px_36px_rgba(255,95,109,0.35)] active:scale-[0.98]"
+          >
+            <span>카카오 로그인하고 내 카드 등록하기 ›</span>
+          </button>
+
+          <div className="mt-5 flex flex-col items-center gap-2 text-xs text-gray-400">
+            <p>🔒 카카오 계정은 로그인 인증용으로만 사용돼요</p>
+            <p>❌ 이름, 친구목록 등 개인정보는 일절 수집하지 않아요</p>
+          </div>
         </div>
-      </div>
+      </section>
     </main>
   );
 };

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+
+const MeetingKakaoLoginPage = () => {
+  const navigate = useNavigate();
+  const handleKakaoLogin = () => {
+    navigate('/meeting/register');
+  };
+  return (
+    <main className="bg-alabaster mx-auto flex min-h-screen w-full max-w-[448px] flex-col items-center justify-center px-6">
+      <div className="mb-12 text-center">
+        <h1 className="mb-2 text-2xl font-bold text-gray-900">미팅 서비스</h1>
+        <p className="text-gray-90 mt-4 text-lg font-semibold">
+          카카오 로그인 후 이용할 수 있어요
+        </p>
+      </div>
+
+      <button
+        onClick={handleKakaoLogin}
+        className="flex w-full items-center justify-center gap-3 rounded-2xl py-4 font-bold text-[#3C1E1E]"
+        style={{ backgroundColor: '#FEE500' }}
+      >
+        카카오로 시작하기
+      </button>
+      <p className="text-body-medium mt-5 text-center leading-relaxed text-gray-500">
+        * 카카오 계정은{' '}
+        <span className="font-semibold text-gray-700">1인 1계정 확인</span>
+        용으로만 사용돼요
+        <br />* 이름, 친구목록 등 개인정보는 일절 수집하지 않아요
+      </p>
+    </main>
+  );
+};
+
+export default MeetingKakaoLoginPage;

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -88,26 +88,24 @@ const MeetingKakaoLoginPage = () => {
         <div className="flex-1">
           <div className="mt-20 text-center">
             <h1 className="text-[32px] leading-tight font-black tracking-[-0.04em] text-gray-900">
-              내 카드를 등록하면
+              내 프로필을 등록하면
               <br />
-              <span className="text-[#FF6B35]">인연 카드를 뽑을 수 있어요</span>
+              <span className="text-[#FF6B35]">
+                인연 프로필을 뽑을 수 있어요
+              </span>
             </h1>
             <p className="mt-3 text-base leading-relaxed font-medium text-gray-500">
-              등록은 딱 한 번, 카드는 축제 기간 동안 유지돼요
+              등록은 딱 한 번, 프로필은 축제 기간 동안 유지돼요
             </p>
           </div>
 
-          <div className="mt-5 flex items-center justify-center gap-3">
-            <span className="text-sm font-semibold text-[#FF5F6D]">
-              ♀ 여자 999명
-            </span>
+          <div className="mt-8 flex items-center justify-center gap-3">
+            <span className="font-semibold text-[#FF5F6D]">♀ 여자 999명</span>
             <span className="h-3.5 w-px bg-gray-200" />
-            <span className="text-sm font-semibold text-[#3B82F6]">
-              ♂ 남자 999명
-            </span>
+            <span className="font-semibold text-[#3B82F6]">♂ 남자 999명</span>
           </div>
 
-          <div className="mt-6 flex flex-col gap-2">
+          <div className="mt-5 flex flex-col gap-2">
             <MeetingInfoCard
               icon="🎟️"
               title={
@@ -116,7 +114,7 @@ const MeetingKakaoLoginPage = () => {
                   <span className="text-[#FF6B35]">1회</span> 열람
                 </>
               }
-              description="내 카드를 등록하면 다른 사람의 카드를 1번 뽑을 수 있어요."
+              description="내 프로필을 등록하면 다른 사람의 프로필을 1번 뽑을 수 있어요."
             />
 
             <MeetingInfoCard
@@ -127,7 +125,7 @@ const MeetingKakaoLoginPage = () => {
                   <span className="text-[#FF6B35]">+1</span>
                 </>
               }
-              description="카드를 뽑은 후 1시간마다 +1의 뽑기 기회가 생겨요. 자주 방문할수록 더 많은 인연을!"
+              description="프로필을 뽑은 후 1시간마다 +1의 뽑기 기회가 생겨요. 자주 방문할수록 더 많은 인연을!"
             />
 
             <MeetingInfoCard
@@ -149,12 +147,18 @@ const MeetingKakaoLoginPage = () => {
             onClick={handleKakaoLogin}
             className="flex w-full cursor-pointer items-center justify-center gap-4 rounded-full bg-gradient-to-r from-[#FF6B35] to-[#FF5F6D] py-4 text-center leading-tight font-bold text-white shadow-[0_16px_36px_rgba(255,95,109,0.35)] active:scale-[0.98]"
           >
-            <span>카카오 로그인하고 내 카드 등록하기 ›</span>
+            <span>카카오 로그인하고 내 프로필 등록하기 ›</span>
           </button>
 
           <div className="mt-5 flex flex-col items-center gap-2 text-xs text-gray-400">
-            <p>🔒 카카오 계정은 로그인 인증용으로만 사용돼요</p>
-            <p>❌ 이름, 친구목록 등 개인정보는 일절 수집하지 않아요</p>
+            <p>
+              🔒 카카오 계정은 로그인 인증용으로 이름 등 개인정보는 수집하지
+              않아요
+            </p>
+            <p>
+              🧡 이미 프로필을 등록하셨다면 로그인 시 바로 인연 목록 페이지가
+              나와요
+            </p>
           </div>
         </div>
       </section>

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useEffect } from 'react';
-import { useKakaoLogin } from '../features/meeting/hooks/useKaKaoLogin';
+import { useEffect, useRef } from 'react';
+import { useKakaoLogin } from '../features/meeting/hooks/useKakaoLogin';
 import { authApi } from '../api/api';
 
 const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
@@ -19,23 +19,26 @@ const MeetingKakaoLoginPage = () => {
     }
   });
 
+  const hasCalledLogin = useRef(false);
+
   useEffect(() => {
     const code = searchParams.get('code');
     const state = searchParams.get('state');
-    if (code && state) {
-      kakaoLogin({ code, state }); //자동으로 mutate 하도록
+    if (code && state && !hasCalledLogin.current) {
+      hasCalledLogin.current = true;
+      kakaoLogin({ code, state });
     }
   }, []);
 
   const handleKakaoLogin = async () => {
-    const { data } = await authApi.get('/meeting/auth/kakao/state');
+    const { data } = await authApi.get('/api/meeting/auth/kakao/state');
 
     window.location.href =
       `https://kauth.kakao.com/oauth/authorize` +
       `?client_id=${KAKAO_CLIENT_ID}` +
       `&redirect_uri=${KAKAO_REDIRECT_URI}` +
       `&response_type=code` +
-      `&state=${data.state}`;
+      `&state=${encodeURIComponent(data.data.state)}`;
   };
   return (
     <main className="bg-alabaster mx-auto flex min-h-screen w-full max-w-[448px] flex-col items-center justify-center px-6">
@@ -48,7 +51,7 @@ const MeetingKakaoLoginPage = () => {
 
       <button
         onClick={handleKakaoLogin}
-        className="flex w-full items-center justify-center gap-3 rounded-2xl py-4 font-bold text-[#3C1E1E]"
+        className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl py-4 font-bold text-[#3C1E1E]"
         style={{ backgroundColor: '#FEE500' }}
       >
         카카오로 시작하기

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -1,9 +1,41 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useKakaoLogin } from '../features/meeting/hooks/useKaKaoLogin';
+import { authApi } from '../api/api';
+
+const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
 const MeetingKakaoLoginPage = () => {
   const navigate = useNavigate();
-  const handleKakaoLogin = () => {
-    navigate('/meeting/register');
+  const [searchParams] = useSearchParams();
+  const { mutate: kakaoLogin } = useKakaoLogin((data) => {
+    if (data.data.newUser) {
+      sessionStorage.setItem('signUpToken', data.data.signUpToken);
+      navigate('/meeting/register?step=gender');
+    } else {
+      localStorage.setItem('accessToken', data.data.accessToken);
+      navigate('/meeting');
+    }
+  });
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    if (code && state) {
+      kakaoLogin({ code, state }); //자동으로 mutate 하도록
+    }
+  }, []);
+
+  const handleKakaoLogin = async () => {
+    const { data } = await authApi.get('/meeting/auth/kakao/state');
+
+    window.location.href =
+      `https://kauth.kakao.com/oauth/authorize` +
+      `?client_id=${KAKAO_CLIENT_ID}` +
+      `&redirect_uri=${KAKAO_REDIRECT_URI}` +
+      `&response_type=code` +
+      `&state=${data.state}`;
   };
   return (
     <main className="bg-alabaster mx-auto flex min-h-screen w-full max-w-[448px] flex-col items-center justify-center px-6">

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -47,6 +47,9 @@ const MeetingKakaoLoginPage = () => {
         <p className="text-gray-90 mt-4 text-lg font-semibold">
           카카오 로그인 후 이용할 수 있어요
         </p>
+        <p className="text-gray-90text-lg mt-1 font-semibold">
+          📱 모바일 이용을 권장드립니다
+        </p>
       </div>
 
       <button

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -61,13 +61,11 @@ const MeetingKakaoLoginPage = () => {
         `}
       </style>
 
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,#FFE4D2_0%,#FFFDF9_48%,#FFFFFF_100%)]" />
-
-      <div className="pointer-events-none absolute inset-0 opacity-60 blur-[1px]">
+      <div className="pointer-events-none fixed inset-0 opacity-60 blur-[1px]">
         {meetingMockProfiles.map((profile, index) => (
           <div
             key={profile.id}
-            className={`absolute ${profile.position} w-[210px] rounded-2xl shadow-[0_8px_32px_rgba(255,107,53,0.2)] ring-1 ring-orange-200`}
+            className={`absolute ${profile.position} w-[210px] rounded-3xl shadow-[0_8px_32px_rgba(255,107,53,0.2)] ring-1 ring-orange-200`}
             style={{
               animation: 'floatUp 12s linear infinite',
               animationDelay: `${index * -2}s`,
@@ -156,7 +154,7 @@ const MeetingKakaoLoginPage = () => {
               않아요
             </p>
             <p>
-              🧡 이미 프로필을 등록하셨다면 로그인 시 바로 인연 목록 페이지가
+              🧡 이미 프로필을 등록하셨다면 로그인 시 바로 인연 프로필 페이지가
               나와요
             </p>
           </div>

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -42,14 +42,16 @@ const MeetingKakaoLoginPage = () => {
   };
   return (
     <main className="bg-alabaster mx-auto flex min-h-screen w-full max-w-[448px] flex-col items-center justify-center px-6">
-      <div className="mb-12 text-center">
-        <h1 className="mb-2 text-2xl font-bold text-gray-900">미팅 서비스</h1>
-        <p className="text-gray-90 mt-4 text-lg font-semibold">
+      <div className="mb-12 flex flex-col items-center gap-2 text-center">
+        <h1 className="text-2xl font-bold text-gray-900">미팅 서비스</h1>
+        <p className="font-semibold text-gray-900">
           카카오 로그인 후 이용할 수 있어요
         </p>
-        <p className="text-gray-90text-lg mt-1 font-semibold">
-          📱 모바일 이용을 권장드립니다
-        </p>
+        <div className="mt-1 flex items-center gap-1 rounded-lg bg-gray-100 px-3 py-1.5">
+          <span className="text-xs text-gray-500">
+            📱 모바일 이용을 권장해요
+          </span>
+        </div>
       </div>
 
       <button
@@ -59,12 +61,21 @@ const MeetingKakaoLoginPage = () => {
       >
         카카오로 시작하기
       </button>
-      <p className="text-body-medium mt-5 text-center leading-relaxed text-gray-500">
-        * 카카오 계정은{' '}
-        <span className="font-semibold text-gray-700">1인 1계정 확인</span>
-        용으로만 사용돼요
-        <br />* 이름, 친구목록 등 개인정보는 일절 수집하지 않아요
-      </p>
+
+      <div className="mt-6 flex w-full flex-col items-center gap-2">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 text-xs text-gray-400">🔒</span>
+          <p className="text-xs leading-relaxed text-gray-400">
+            카카오 계정은 로그인 인증용으로만 사용돼요
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <span className="mt-0.5 text-xs text-gray-400">❌</span>
+          <p className="text-xs leading-relaxed text-gray-400">
+            이름, 친구목록 등 개인정보는 일절 수집하지 않아요
+          </p>
+        </div>
+      </div>
     </main>
   );
 };

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -16,7 +16,6 @@ function MeetingPage() {
   const { mutate: openCard, isPending: isOpening } = useOpenCard((data) => {
     setOpenCardResult(data);
   });
-  const navigate = useNavigate();
 
   const handleOpenCard = (profileId: number) => {
     openCard(profileId);
@@ -28,7 +27,6 @@ function MeetingPage() {
       position: 'top-center',
       autoClose: 3000,
     });
-    navigate('/');
   };
 
   return (
@@ -65,7 +63,7 @@ function MeetingPage() {
           <div className="flex flex-col items-center justify-center gap-4 py-20">
             <span className="text-4xl">🌸</span>
             <span className="text-body-regular text-jumbo">
-              아직 등록된 프로필이 없어요🥲
+              아직 등록된 프로필이 없어요 🥲
               <br /> 잠시 후 다시 방문해주세요.
             </span>
           </div>

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -3,9 +3,7 @@ import { useMeetingProfiles } from '../features/meeting/hooks/useMeetingProfiles
 import { useOpenCard } from '../features/meeting/hooks/useOpenCard';
 import ProfileCardList from '../features/meeting/components/ProfileCardList';
 import ContactRevealModal from '../features/meeting/components/ContactRevealModal';
-import { TodayConnectionIcon } from '../components/icons';
 import type { CardOpenResponse } from '../types/meetingType';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 function MeetingPage() {
@@ -31,22 +29,45 @@ function MeetingPage() {
 
   return (
     <main className="bg-meeting-surface mx-auto flex min-h-screen w-full max-w-[448px] flex-col">
-      <header
-        className="sticky top-0 z-10 w-full"
-        style={{
-          background: 'rgba(250, 250, 250, 0.8)',
-          backdropFilter: 'blur(8px)',
-        }}
-      >
-        <div className="flex w-full flex-row items-center justify-between px-5 py-4">
-          <div className="flex flex-row items-center gap-2">
-            <TodayConnectionIcon />
+      <header className="sticky top-0 z-10 w-full">
+        {/* 메인 헤더 */}
+        <div
+          className="flex w-full flex-row items-center justify-between px-5 py-4"
+          style={{
+            background: 'rgba(255, 253, 249, 0.85)',
+            backdropFilter: 'blur(10px)',
+            borderBottom: '1px solid rgba(255, 107, 53, 0.08)',
+          }}
+        >
+          <div className="flex flex-col gap-0.5">
             <span className="text-heading-2 text-shark">나의 인연 찾기</span>
+            <p className="text-sm text-gray-400">
+              카드를 눌러 연락처를 확인해보세요
+            </p>
           </div>
+          <div className="flex flex-col items-end gap-0.5">
+            <span className="text-2xl leading-none font-black">999명</span>{' '}
+            <span className="text-xs text-gray-400">의 이성 프로필 등록됨</span>
+          </div>
+        </div>
+
+        <div
+          className="flex w-full flex-row items-center justify-between px-5 py-2.5"
+          style={{
+            background: 'rgba(255, 107, 53, 0.06)',
+            borderBottom: '1px solid rgba(255, 107, 53, 0.1)',
+          }}
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm text-gray-500">🎟️ 뽑기 기회</span>
+            <span className="text-sm font-black">N회</span>
+            <span className="text-sm text-gray-400">남음</span>
+          </div>
+          <span className="text-xs text-gray-400">00분 00초 후 +1 충전</span>
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="mt-4 flex-1 overflow-y-auto">
         {isLoading && (
           <div className="flex items-center justify-center py-20">
             <span className="text-body-regular text-jumbo">불러오는 중...</span>

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -38,7 +38,7 @@ function MeetingPage() {
         <div className="flex w-full flex-row items-center justify-between px-5 py-4">
           <div className="flex flex-row items-center gap-2">
             <TodayConnectionIcon />
-            <span className="text-heading-2 text-shark">오늘의 인연</span>
+            <span className="text-heading-2 text-shark">나의 인연 찾기</span>
           </div>
           <button
             type="button"

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -72,13 +72,6 @@ function MeetingPage() {
             <span className="text-body-regular text-jumbo">
               아직 등록된 프로필이 없어요
             </span>
-            <button
-              type="button"
-              onClick={() => navigate('/meeting/register')}
-              className="bg-main-gradient text-body-medium cursor-pointer rounded-full px-6 py-3 font-bold text-white"
-            >
-              내 프로필 등록하기
-            </button>
           </div>
         )}
         {profiles && profiles.length > 0 && (

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -5,16 +5,18 @@ import ProfileCardList from '../features/meeting/components/ProfileCardList';
 import ContactRevealModal from '../features/meeting/components/ContactRevealModal';
 import { TodayConnectionIcon } from '../components/icons';
 import type { CardOpenResponse } from '../types/meetingType';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 function MeetingPage() {
   const { data: profiles, isLoading, isError } = useMeetingProfiles();
   const [openCardResult, setOpenCardResult] = useState<CardOpenResponse | null>(
     null,
   );
-
   const { mutate: openCard } = useOpenCard((data) => {
     setOpenCardResult(data);
   });
+  const navigate = useNavigate();
 
   const handleOpenCard = (profileId: number) => {
     openCard(profileId);
@@ -22,6 +24,11 @@ function MeetingPage() {
 
   const handleCloseModal = () => {
     setOpenCardResult(null);
+    toast('💚 또 만나요! 새로운 인연이 기다리고 있어요', {
+      position: 'top-center',
+      autoClose: 3000,
+    });
+    navigate('/');
   };
 
   return (
@@ -58,7 +65,8 @@ function MeetingPage() {
           <div className="flex flex-col items-center justify-center gap-4 py-20">
             <span className="text-4xl">🌸</span>
             <span className="text-body-regular text-jumbo">
-              아직 등록된 프로필이 없어요
+              아직 등록된 프로필이 없어요🥲
+              <br /> 잠시 후 다시 방문해주세요.
             </span>
           </div>
         )}
@@ -70,7 +78,6 @@ function MeetingPage() {
       {openCardResult && (
         <ContactRevealModal
           contact={openCardResult.contact}
-          remainOpenCount={openCardResult.remainOpenCount}
           onClose={handleCloseModal}
         />
       )}

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -21,7 +21,7 @@ function MeetingPage() {
 
   const handleCloseModal = () => {
     setOpenCardResult(null);
-    toast('💚 또 만나요! 새로운 인연이 기다리고 있어요', {
+    toast('🧡 또 만나요! 새로운 인연이 기다리고 있어요', {
       position: 'top-center',
       autoClose: 3000,
     });

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -13,7 +13,7 @@ function MeetingPage() {
   const [openCardResult, setOpenCardResult] = useState<CardOpenResponse | null>(
     null,
   );
-  const { mutate: openCard } = useOpenCard((data) => {
+  const { mutate: openCard, isPending: isOpening } = useOpenCard((data) => {
     setOpenCardResult(data);
   });
   const navigate = useNavigate();
@@ -71,7 +71,11 @@ function MeetingPage() {
           </div>
         )}
         {profiles && profiles.length > 0 && (
-          <ProfileCardList profiles={profiles} onOpenCard={handleOpenCard} />
+          <ProfileCardList
+            profiles={profiles}
+            onOpenCard={handleOpenCard}
+            isOpening={isOpening}
+          />
         )}
       </div>
 

--- a/src/pages/MeetingPage.tsx
+++ b/src/pages/MeetingPage.tsx
@@ -1,14 +1,12 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useMeetingProfiles } from '../features/meeting/hooks/useMeetingProfiles';
 import { useOpenCard } from '../features/meeting/hooks/useOpenCard';
 import ProfileCardList from '../features/meeting/components/ProfileCardList';
 import ContactRevealModal from '../features/meeting/components/ContactRevealModal';
-import { TodayConnectionIcon, CoinIcon } from '../components/icons';
+import { TodayConnectionIcon } from '../components/icons';
 import type { CardOpenResponse } from '../types/meetingType';
 
 function MeetingPage() {
-  const navigate = useNavigate();
   const { data: profiles, isLoading, isError } = useMeetingProfiles();
   const [openCardResult, setOpenCardResult] = useState<CardOpenResponse | null>(
     null,
@@ -40,16 +38,6 @@ function MeetingPage() {
             <TodayConnectionIcon />
             <span className="text-heading-2 text-shark">나의 인연 찾기</span>
           </div>
-          <button
-            type="button"
-            onClick={() => navigate('/meeting/register')}
-            className="bg-choice-header-gradient flex cursor-pointer flex-row items-center gap-1.5 rounded-full px-4 py-2"
-          >
-            <CoinIcon className="h-5 w-5" />
-            <span className="text-caption font-bold text-white">
-              {openCardResult?.remainOpenCount ?? 1}개
-            </span>
-          </button>
         </div>
       </header>
 

--- a/src/pages/MeetingRegisterPage.tsx
+++ b/src/pages/MeetingRegisterPage.tsx
@@ -20,7 +20,7 @@ const STEPS = [
 type StepKey = (typeof STEPS)[number];
 
 interface RegisterFormState {
-  gender: '남' | '여' | null;
+  gender: 'MALE' | 'FEMALE' | null;
   faceType: string | null;
   birthYear: number;
   hobby: string;
@@ -88,11 +88,11 @@ function MeetingRegisterPage() {
       return;
 
     registerProfile({
-      gender: formState.gender as '남' | '여',
+      gender: formState.gender as 'MALE' | 'FEMALE',
       faceType: formState.faceType as string,
       birthYear: formState.birthYear,
       hobby: formState.hobby.trim(),
-      desiredDate: formState.dateStyle.trim(),
+      dateStyle: formState.dateStyle.trim(),
       contact: formState.contact.trim(),
     });
   };

--- a/src/pages/MeetingRegisterPage.tsx
+++ b/src/pages/MeetingRegisterPage.tsx
@@ -13,7 +13,7 @@ const STEPS = [
   'faceType',
   'birthYear',
   'hobby',
-  'desiredDate',
+  'dateStyle',
   'contact',
 ] as const;
 
@@ -24,7 +24,7 @@ interface RegisterFormState {
   faceType: string | null;
   birthYear: number;
   hobby: string;
-  desiredDate: string;
+  dateStyle: string;
   contact: string;
 }
 
@@ -34,7 +34,7 @@ const STEP_VALIDATION: Record<StepKey, (state: RegisterFormState) => boolean> =
     faceType: (state) => state.faceType !== null,
     birthYear: () => true,
     hobby: (state) => state.hobby.trim().length > 0,
-    desiredDate: (state) => state.desiredDate.trim().length > 0,
+    dateStyle: (state) => state.dateStyle.trim().length > 0,
     contact: (state) => state.contact.trim().length > 0,
   };
 
@@ -54,7 +54,7 @@ function MeetingRegisterPage() {
     faceType: null,
     birthYear: 2002,
     hobby: '',
-    desiredDate: '',
+    dateStyle: '',
     contact: '',
   });
 
@@ -92,7 +92,7 @@ function MeetingRegisterPage() {
       faceType: formState.faceType as string,
       birthYear: formState.birthYear,
       hobby: formState.hobby.trim(),
-      desiredDate: formState.desiredDate.trim(),
+      desiredDate: formState.dateStyle.trim(),
       contact: formState.contact.trim(),
       remainPickCount: 5,
     });
@@ -126,13 +126,13 @@ function MeetingRegisterPage() {
         onChange={updateFormState('hobby')}
       />
     ),
-    desiredDate: (
+    dateStyle: (
       <TextareaStep
         title="원하는 데이트는?"
         description="하고싶은 데이트를 적어주세요"
         placeholder="예: 한강에서 치맥하며 수다떨기"
-        value={formState.desiredDate}
-        onChange={updateFormState('desiredDate')}
+        value={formState.dateStyle}
+        onChange={updateFormState('dateStyle')}
       />
     ),
     contact: (

--- a/src/pages/MeetingRegisterPage.tsx
+++ b/src/pages/MeetingRegisterPage.tsx
@@ -28,16 +28,6 @@ interface RegisterFormState {
   contact: string;
 }
 
-const STEP_VALIDATION: Record<StepKey, (state: RegisterFormState) => boolean> =
-  {
-    gender: (state) => state.gender !== null,
-    faceType: (state) => state.faceType !== null,
-    birthYear: () => true,
-    hobby: (state) => state.hobby.trim().length > 0,
-    dateStyle: (state) => state.dateStyle.trim().length > 0,
-    contact: (state) => state.contact.trim().length > 0,
-  };
-
 function MeetingRegisterPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -59,6 +49,35 @@ function MeetingRegisterPage() {
   });
 
   const { mutate: registerProfile, isPending } = useRegisterProfile();
+
+  const STEP_VALIDATION: Record<
+    StepKey,
+    (state: RegisterFormState) => boolean
+  > = {
+    gender: (state) => state.gender !== null,
+    faceType: (state) => state.faceType !== null,
+    birthYear: () => true,
+    hobby: (state) =>
+      state.hobby.trim().length > 0 && state.hobby.trim().length <= 20,
+    dateStyle: (state) =>
+      state.dateStyle.trim().length > 0 && state.dateStyle.trim().length <= 30,
+    contact: (state) => state.contact.trim().length > 0,
+  };
+
+  const getStepError = (): string | null => {
+    if (currentStepKey === 'hobby' && formState.hobby.trim().length > 20) {
+      return '취미/특기는 20자 이내로 적어주세요';
+    }
+    if (
+      currentStepKey === 'dateStyle' &&
+      formState.dateStyle.trim().length > 30
+    ) {
+      return '데이트 스타일은 30자 이내로 적어주세요';
+    }
+    return null;
+  };
+
+  const stepError = getStepError();
 
   useEffect(() => {
     if (currentStepIndex > 0 && formState.gender === null) {
@@ -118,18 +137,20 @@ function MeetingRegisterPage() {
     ),
     hobby: (
       <TextareaStep
-        title="취미/특기를 알려주세요"
-        description="자신의 취미나 특기를 적어주세요"
-        placeholder="예: 한강에서 치맥하며 수다떨기"
+        title="당신의 취미/특기는?"
+        maxLength={20}
+        description="자신의 취미나 특기를 적어주세요 (20자 이내)"
+        placeholder="예: 클라이밍, 요가"
         value={formState.hobby}
         onChange={updateFormState('hobby')}
       />
     ),
     dateStyle: (
       <TextareaStep
-        title="원하는 데이트는?"
-        description="하고싶은 데이트를 적어주세요"
-        placeholder="예: 한강에서 치맥하며 수다떨기"
+        title="당신이 원하는 데이트는?"
+        maxLength={30}
+        description="하고싶은 데이트를 적어주세요 (30자 이내)"
+        placeholder="예: 한강에서 치맥하기"
         value={formState.dateStyle}
         onChange={updateFormState('dateStyle')}
       />
@@ -159,9 +180,14 @@ function MeetingRegisterPage() {
       >
         <div className="flex-1">{renderStep()}</div>
         <div className="mt-4 flex flex-col gap-0">
+          {stepError && (
+            <p className="mb-2 text-center text-sm text-red-400">{stepError}</p>
+          )}
           <button
             type={currentStepIndex === STEPS.length - 1 ? 'submit' : 'button'}
-            onClick={handleNext}
+            onClick={
+              currentStepIndex === STEPS.length - 1 ? undefined : handleNext
+            }
             disabled={!isCurrentStepValid || isPending}
             className={`text-button w-full cursor-pointer rounded-2xl py-4 font-bold text-white transition-opacity ${
               isCurrentStepValid && !isPending

--- a/src/pages/MeetingRegisterPage.tsx
+++ b/src/pages/MeetingRegisterPage.tsx
@@ -94,7 +94,6 @@ function MeetingRegisterPage() {
       hobby: formState.hobby.trim(),
       desiredDate: formState.dateStyle.trim(),
       contact: formState.contact.trim(),
-      remainPickCount: 5,
     });
   };
 

--- a/src/types/meetingType.ts
+++ b/src/types/meetingType.ts
@@ -1,20 +1,20 @@
 export interface Profile {
   id: number;
-  gender: '남' | '여';
+  gender: 'MALE' | 'FEMALE';
   faceType: string;
   birthYear: number;
   hobby: string;
-  desiredDate: string;
+  dateStyle: string;
   selfAppeal?: string;
   remainPickCount: number;
 }
 
 export interface ProfileRegisterPayload {
-  gender: '남' | '여';
+  gender: 'MALE' | 'FEMALE';
   faceType: string;
   birthYear: number;
   hobby: string;
-  desiredDate: string;
+  dateStyle: string;
   selfAppeal?: string;
   contact: string;
 }

--- a/src/types/meetingType.ts
+++ b/src/types/meetingType.ts
@@ -21,5 +21,4 @@ export interface ProfileRegisterPayload {
 
 export interface CardOpenResponse {
   contact: string;
-  remainOpenCount: number;
 }

--- a/src/types/meetingType.ts
+++ b/src/types/meetingType.ts
@@ -6,7 +6,6 @@ export interface Profile {
   hobby: string;
   dateStyle: string;
   selfAppeal?: string;
-  remainPickCount: number;
 }
 
 export interface ProfileRegisterPayload {

--- a/src/types/meetingType.ts
+++ b/src/types/meetingType.ts
@@ -17,7 +17,6 @@ export interface ProfileRegisterPayload {
   desiredDate: string;
   selfAppeal?: string;
   contact: string;
-  remainPickCount: number;
 }
 
 export interface CardOpenResponse {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,15 @@ import { defineConfig as defineVitestConfig } from 'vitest/config';
 
 export default defineVitestConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://api.sejonglife.site',
+        changeOrigin: true,
+        secure: true,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 카카오 로그인 플로우 구축
- [x] 백엔드 api 연결(연결한 사항은 주요 변경사항에 더 담아두겠습니다 !)
- [x] 미팅 메인페이지(카카오 로그인페이지), 미팅목록 페이지 UI 변경

### 📋 주요 변경사항 (Key Changes)

현재 미팅서비스의 로직은 다음과 같습니다.
- 사용자가 배너를 통해 진입한다.
- 미팅서비스에 대한 내용을 소개하고 카카오 로그인을 유도한다.
- 카카오 로그인 버튼 클릭 시에 /api/meeting/auth/kakao/state 로 백엔드에 카카오 로그인 페이지에 접근할 수 있는 리다이렉트 uri를 요청한다.
- 해당 값을 통해 카카오 로그인 페이지로 이동하고 로그인을 진행한다.
- 로그인이 완료되면 카카오로 부터 받은 인가코드를 담아 /api/meeting/auth/kakao/login 로 백엔드에 로그인 요청을 한다.
- 백엔드에서는 isNewUser(boolean)값과 함께 신규유저면 signUpToken을 내려주고 기존유저면 accessToken을 내려준다. 
- 우리는 백에서 받은 isNewUser값을 가지고 기존 유저면 목록페이지로 이동을 시키고 신규 유저면 등록페이지로 이동을 시킨다.
- 프로필을 등록한 후에는 /api/meeting/auth/signup 로 백엔드에 프로필 필드들을 담아서 포스트 요청을 보낸다.
- 해당 등록이 완성이 되면 프로필 페이지로 이동을 하고 이때 우리는 /api/meeting/profiles 로 get 요청을 보내 프로필 목록을 받아온다. (이때 백엔드에서 내부적으로 알아서 이성의 프로필만 전달을 해준다)
- 사용자가 카드를 클릭하면 accessToken의 유무로 오픈을 할지 말지를 정하고 있으며 /api/meeting/profiles/{profileId}/open으로 백엔드에 get 요청을 보내면 백에서 연락처를 내려주고 이를 띄워준다. (연락처모달에서는 연락처를 저장할 수 있는 버튼도 추가했습니다.)
-> 다만 남은 기회에 대해서 카드 오픈 유무를 결정하도록 수정해야합니다 ! (아직 백엔드 작업이 안된건지 스웨거 반영이 안된건지 확인이 안돼서 진행하지 못했습니다.)


---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: #217 

---

### 📸 스크린샷 (Screenshot)

- 배너
<img width="325" height="702" alt="image" src="https://github.com/user-attachments/assets/338fd9e0-f639-481f-b736-6449a93c408c" />

- 미팅부스 메인 (이게 진짜 진짜 제법 오랜 시간 걸려서 했는데... 정신이 없나 싶기도 하고... 슬프네요 뒤에 카드들은 저렇게 정지 아니고 움직여요 요리조리) 
<img width="325" height="702" alt="image" src="https://github.com/user-attachments/assets/5ac2749c-1350-4b0a-a82c-e8051ef27789" />

- 등록
<img width="325" height="702" alt="image" src="https://github.com/user-attachments/assets/1ef92fbc-81e7-4a4d-b1cf-af3a55f2a104" />

- 이성 프로필 목록
<img width="325" height="702" alt="image" src="https://github.com/user-attachments/assets/a53b2274-a869-4786-af74-714ce7ea7e0a" />

- 이성 프로필 클릭 후 뜨는 연락처 (저거 카드 적은 제 친구가 연락처란에 안녕이라고 해놔서 그래요 !)
<img width="325" height="702" alt="image" src="https://github.com/user-attachments/assets/e2d470e1-9607-46b9-863a-cd179383f0a2" />


---

### ✅ 참고 사항 (Remarks)

뜨는 프로필들은 제가 친구들 시켜서 한거라 저 포함해서 3명인가 4명 되어있을거에요 !  (이 데이터들은 출시 전 삭제 하고 시작하면 될 것 같슴다)

남은 기능 구현
1. 유저가 카드를 오픈할때 남은횟수를 기반으로 오픈을 하도록 하는 로직
2. 이미 열었던 카드에 대해서는 이미 오픈했던 카드임을 전달하기
3. 현재 등록된 프로필 수 api 연결해서 응답값을 띄우기 (/meeting/kakoLogin, /meeting 이 두가지 페이지에 연결 바랍니다 !)
4. 1시간 후 +1 기회 받는 것과 관련된 로직 (오픈 한 후에 백엔드로 요청 및 남은 시간 띄우기)
5. url로 페이지 이동이 안되도록 막기 (이는 개발 중에는 불필요해서 아직 안 해놨는데 기능 구현 끝나면 MeetingProtectedRoute 같은거 새로 만들어서 막아야할 것 같아요)