### PR TITLE
fix: 미팅로그인과 기존로그인 분리

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,3 +26,22 @@ authApi.interceptors.request.use(
     return Promise.reject(error);
   },
 );
+
+export const meetingAuthApi = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10000,
+  withCredentials: true,
+});
+
+meetingAuthApi.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('meetingAccessToken');
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);

--- a/src/features/meeting/apis/meetingApi.ts
+++ b/src/features/meeting/apis/meetingApi.ts
@@ -1,4 +1,4 @@
-import { api, authApi } from '../../../api/api';
+import { api, meetingAuthApi } from '../../../api/api';
 import type {
   Profile,
   ProfileRegisterPayload,
@@ -9,12 +9,12 @@ import type {
 } from '../../../types/meetingType';
 
 export const fetchMeetingProfiles = async (): Promise<Profile[]> => {
-  const response = await authApi.get('/api/meeting/profiles');
+  const response = await meetingAuthApi.get('/api/meeting/profiles');
   return response.data;
 };
 
 export const fetchOpenCount = async (): Promise<OpenCountResponse> => {
-  const response = await authApi.get('/api/meeting/profiles/open-count');
+  const response = await meetingAuthApi.get('/api/meeting/profiles/open-count');
   return response.data?.data ?? response.data;
 };
 
@@ -29,7 +29,7 @@ export const registerMeetingProfile = async (
   const signUpToken = sessionStorage.getItem('signUpToken');
   const ref = sessionStorage.getItem('meetingRef');
 
-  const response = await authApi.post('/api/meeting/auth/signup', payload, {
+  const response = await api.post('/api/meeting/auth/signup', payload, {
     headers: {
       Authorization: `Bearer ${signUpToken}`,
     },
@@ -41,7 +41,7 @@ export const registerMeetingProfile = async (
 export const openMeetingCard = async (
   profileId: number,
 ): Promise<CardOpenResponse> => {
-  const response = await authApi.post(
+  const response = await meetingAuthApi.post(
     `/api/meeting/profiles/${profileId}/open`,
   );
   return response.data;

--- a/src/features/meeting/components/MeetingProtectedRoute.tsx
+++ b/src/features/meeting/components/MeetingProtectedRoute.tsx
@@ -14,7 +14,7 @@ const MeetingProtectedRoute = ({
   const navigate = useNavigate();
   const hasAccess =
     tokenType === 'access'
-      ? !!localStorage.getItem('accessToken')
+      ? !!localStorage.getItem('meetingAccessToken')
       : !!sessionStorage.getItem('signUpToken');
 
   useEffect(() => {

--- a/src/features/meeting/hooks/useRegisterProfile.ts
+++ b/src/features/meeting/hooks/useRegisterProfile.ts
@@ -13,7 +13,7 @@ export const useRegisterProfile = () => {
     mutationFn: (payload: ProfileRegisterPayload) =>
       registerMeetingProfile(payload),
     onSuccess: (data) => {
-      localStorage.setItem('accessToken', data.data.accessToken);
+      localStorage.setItem('meetingAccessToken', data.data.accessToken);
       localStorage.setItem('kakaoId', data.data.kakaoId);
       sessionStorage.removeItem('signUpToken');
       sessionStorage.removeItem('meetingRef');

--- a/src/pages/MeetingKaKaoLoginPage.tsx
+++ b/src/pages/MeetingKaKaoLoginPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import { useKakaoLogin } from '../features/meeting/hooks/useKakaoLogin';
 import { useProfileCount } from '../features/meeting/hooks/useProfileCount';
-import { authApi } from '../api/api';
+import { api } from '../api/api';
 import { MeetingInfoCard } from '../features/meeting/components/MeetingInfoCard';
 import ProfileCard from '../features/meeting/components/ProfileCard';
 import { meetingMockProfiles } from '../features/meeting/mock/meetingMockProfiles';
@@ -21,7 +21,7 @@ const MeetingKakaoLoginPage = () => {
       sessionStorage.setItem('signUpToken', data.data.signUpToken);
       navigate('/meeting/register?step=gender');
     } else {
-      localStorage.setItem('accessToken', data.data.accessToken);
+      localStorage.setItem('meetingAccessToken', data.data.accessToken);
       navigate('/meeting');
     }
   });
@@ -46,7 +46,7 @@ const MeetingKakaoLoginPage = () => {
   }, [searchParams, kakaoLogin]);
 
   const handleKakaoLogin = async () => {
-    const { data } = await authApi.get('/api/meeting/auth/kakao/state');
+    const { data } = await api.get('/api/meeting/auth/kakao/state');
 
     window.location.href =
       `https://kauth.kakao.com/oauth/authorize` +


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] 로그인 로직 완전 분리

### 📋 주요 변경사항 (Key Changes)

카카오 redirect URI가 배포 환경 기준으로만 등록되어 있어 로컬에서 카카오 로그인 플로우 전체를 직접 테스트하지 못했습니다. 로직 변경 자체는 토큰 저장 키와 axios 인스턴스 분리에 한정되므로 코드 리뷰로 검증 부탁드립니다.

---

### 💡 주요 이슈 (Issue)

---

### 📸 스크린샷 (Screenshot)

![스크린샷 제목](스크린샷 이미지 URL)
_변경 사항을 시각적으로 보여주는 스크린샷이나 GIF를 첨부해주세요._

---

### ✅ 참고 사항 (Remarks)

- 카카오 redirect URI가 배포 환경 기준으로만 등록되어 있어 로컬에서 카카오 로그인 플로우 전체를 직접 테스트하지 못했습니다. 로직 변경 자체는 토큰 저장 키와 axios 인스턴스 분리 정도인데 그래도 테스트를 못해보고 작성한 코드라서 한번 같이 확인해주시면 좋을 것 같습니다 !
