### PR TITLE
229 refactor login

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,12 @@
 import axios from 'axios';
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import type { ReissueResponse } from '../types/type';
 
 const BASE_URL = import.meta.env.VITE_API_URL;
+
+interface RetriableRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
 
 export const api = axios.create({
   baseURL: BASE_URL,
@@ -24,6 +30,68 @@ authApi.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
+  },
+);
+
+let isRefreshing = false;
+let refreshSubscribers: ((accessToken: string) => void)[] = [];
+
+const subscribeTokenRefresh = (callback: (accessToken: string) => void) => {
+  refreshSubscribers.push(callback);
+};
+
+const onTokenRefreshed = (accessToken: string) => {
+  refreshSubscribers.forEach((callback) => callback(accessToken));
+  refreshSubscribers = [];
+};
+
+const handleRefreshFailure = () => {
+  refreshSubscribers = [];
+  localStorage.removeItem('accessToken');
+  window.location.href = '/';
+};
+
+authApi.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as RetriableRequestConfig | undefined;
+
+    if (
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry
+    ) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    if (isRefreshing) {
+      return new Promise((resolve) => {
+        subscribeTokenRefresh((accessToken) => {
+          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+          resolve(authApi(originalRequest));
+        });
+      });
+    }
+
+    isRefreshing = true;
+
+    try {
+      const { data } = await api.post<ReissueResponse>('/api/auth/reissue');
+      const newAccessToken = data.data.accessToken;
+
+      localStorage.setItem('accessToken', newAccessToken);
+      onTokenRefreshed(newAccessToken);
+
+      originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+      return authApi(originalRequest);
+    } catch (refreshError) {
+      handleRefreshFailure();
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+    }
   },
 );
 

--- a/src/features/login/api/loginApi.ts
+++ b/src/features/login/api/loginApi.ts
@@ -1,4 +1,4 @@
-import { api } from '../../../api/api';
+import { api, authApi } from '../../../api/api';
 import type { LoginPayload, LoginResponse } from '../../../types/type';
 
 interface SignUpPayload {
@@ -22,6 +22,10 @@ export const requestLogin = async (
     console.error('로그인 실패:', error);
     throw error;
   }
+};
+
+export const requestLogout = async (): Promise<void> => {
+  await authApi.post('/api/auth/logout');
 };
 
 export const requestSignUp = async (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import type { UserProfileResponseProps } from '../types/type';
 import { getMyProfile } from '../features/myPage/apis/getMyProfile';
 import deleteUser from '../features/myPage/apis/deleteUser';
+import { requestLogout } from '../features/login/api/loginApi';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 
@@ -38,10 +39,16 @@ function MyPage() {
   if (error) return <div>유저 정보를 불러오지 못했어요</div>;
   if (!myProfile) return null;
 
-  const handleLogout = () => {
-    localStorage.removeItem('accessToken');
-    setIsLoggedIn(false);
-    navigate('/', { replace: true });
+  const handleLogout = async () => {
+    try {
+      await requestLogout();
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+    } finally {
+      localStorage.removeItem('accessToken');
+      setIsLoggedIn(false);
+      navigate('/', { replace: true });
+    }
   };
 
   const handleMembershipCancellation = async () => {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -138,6 +138,15 @@ export interface LoginResponse {
   data: LoginResponseProps;
 }
 
+export interface ReissueResponseProps {
+  accessToken: string;
+}
+
+export interface ReissueResponse {
+  message: string;
+  data: ReissueResponseProps;
+}
+
 export interface UserProfileResponseProps {
   name: string;
   nickname: string;


### PR DESCRIPTION
### 🧐 작업 내용 (Task)

- [x] accessToken + RefreshToken 방식으로 수정
- [x] 로그아웃 api 연동 추가

### 📋 주요 변경사항 (Key Changes)

## 1. 백엔드(#188)에서 로그인/재발급 응답이 accessToken(body) + refreshToken(httpOnly 쿠키) 두 개를 내려주는 방식으로 바뀌어서, 프론트도 이에 맞춰 반영
- accessToken: 기존과 동일하게 응답 body에서 받아 localStorage에 저장, 매 요청 시 Authorization 헤더에 부착
- refreshToken: 프론트가 직접 다루지 않음. 백엔드가 로그인 시 httpOnly + Secure + SameSite=Lax 쿠키로 자동 설정하고, 브라우저가 자동으로 저장/전송
- authApi(axios)에 response 인터셉터를 추가해 accessToken 만료(401) 시 `/api/auth/reissue`를 호출해 자동으로 재발급받고, 실패했던 원래 요청을 재시도하도록 구현
- 여러 요청이 동시에 401을 맞아도 reissue는 1회만 호출되도록 큐잉 처리(중복 재발급 방지)
- reissue 자체가 실패하면(=refreshToken도 만료/폐기) accessToken을 지우고 로그인 페이지로 이동

## 2. accessToken까지 쿠키로 옮기지 못한 이유
- 백엔드 인증 로직(`AuthInterceptor`, `AuthUserArgumentResolver`)이 Authorization 헤더 기반으로 동작해서, accessToken을 httpOnly 쿠키로 바꾸면 JS가 헤더에 실을 값을 읽을 수 없어 인증 자체가 불가능해집니다. 쿠키 기반 인증으로 전환하려면 백엔드가 모든 인증 필요 API에서 쿠키를 읽도록 바뀌어야 하고, 쿠키는 브라우저가 자동으로 실어 보내는 특성상 CSRF 방어(SameSite 강화 + CSRF 토큰)도 추가로 필요해 이번 스코프에서는 제외했습니다.

- **참고**: 이번 변경으로 accessToken의 저장 위치(localStorage) 자체가 바뀐 건 아니라서, XSS로 인한 accessToken 노출 위험은 그대로 남아있습니다. 다만 자동 재발급 흐름이 생겨서 accessToken 수명을 짧게 가져가도 사용자 경험에 영향이 없어졌고(노출 시간 축소), refreshToken은 처음부터 httpOnly로 안전하게 격리되어 있어 재발급 체인 자체는 안전합니다.

## 3. 로그아웃 구현
기존에는 로그아웃 시 프론트 로컬 상태(accessToken, isLoggedIn)만 지우고 백엔드에는 아무 요청도 보내지 않아, 로그아웃 후에도 서버(Redis)의 refreshToken이 최대 14일간 그대로 남아있는 문제가 발생할 수 있었습니다. `/api/auth/logout` 호출을 추가해 서버 세션(Redis 삭제 + 쿠키 만료)도 함께 정리되도록 수정했습니다. 백엔드 호출이 실패하더라도 로컬 상태 정리 및 리다이렉트는 항상 수행되도록 처리했습니다.

---

### 💡 주요 이슈 (Issue)

- **해결한 이슈**: #229 

---


---

### ✅ 참고 사항 (Remarks)

- 다음 회의때 백엔드에 액세스토큰도 쿠키로 보내도록 수정하는 방안을 요청해야할 것 같습니다.